### PR TITLE
Use standard setuptools method to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 Kamodo is a tool for interacting with space weather models for use in visualization, research, education, and operations. Kamodo provides access to space weather models through readers and interpolators, and returns results in the users's preferred units coordinate system.
 
 ## Resources
-SciVision, Inc
 
-    https://www.scivision.co/f2py-running-fortran-code-in-python-on-windows/
+Examples of using Numpy `f2py` to compile Fortran code into importable Python modules:
+
+    https://www.scivision.dev/f2py-running-fortran-code-in-python-on-windows/
     https://github.com/scivision/f2py-examples
 
 Tutorial: Using Fortran from Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,28 @@
 [metadata]
+name = kamodo
+version = 0.0.2
+author = Asher Pembroke
+author_email = apembroke@gmail.com
+description = A functional api for scientific data
+url = https://ccmc.gsfc.nasa.gov/Kamodo/
 license_file = LICENSE
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers =
+	Programming Language :: Python :: 3.7
+	Operating System :: OS Independent
+	License :: OSI Approved
+license = NASA OPEN SOURCE AGREEMENT VERSION 1.3
+
+[options]
+python_requires = >= 3.6
+include_package_data = True
+packages = find:
+install_requires =
+  numpy
+  scipy
+  sympy
+  pandas
+  plotly
+  pytest
+  click

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,3 @@
 import setuptools
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
-
-setuptools.setup(
-    name = 'kamodo',
-    version = '0.0.2',
-    author = 'Asher Pembroke',
-    author_email = 'apembroke@gmail.com',
-    description = 'A functional api for scientific data',
-    long_description = long_description,
-    long_description_content_type = "text/markdown",
-    url = 'https://ccmc.gsfc.nasa.gov/Kamodo/',
-    packages = setuptools.find_packages(),
-    classifiers = [
-		"Programming Language :: Python :: 3.7",
-	    "Operating System :: OS Independent",
-	    "License :: OSI Approved",
-    ],
-    install_requires = [
-		'numpy',
-		'scipy',
-		'sympy',
-		'pandas',
-		'plotly',
-		'pytest',
-        'click',
-    	],
-    license='NASA OPEN SOURCE AGREEMENT VERSION 1.3',
-
-)
-
+setuptools.setup()


### PR DESCRIPTION
using setup.py is often unnecessary and deprecated vs. the declarative setup.cfg. Pyproject.toml tells the installer to use setuptools. This is the current standard way to have a Python package install with setuptools.