### PR TITLE
The README file in this repo has 2 bad links - [404:NotFound]

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ import plotly.io as pio
 fig = kamodo.plot('fvec')
 pio.write_image(fig, 'images/fig2d-usage.svg')
 ```
-![usage](notebooks/images/fig2d-usage.svg)
+![usage](docs/notebooks/images/fig2d-usage.svg)
 
-Head over to the [Introduction](notebooks/Kamodo.ipynb) page for more details.
+Head over to the [Introduction](docs/notebooks/Kamodo.ipynb) page for more details.
 
 
 ## Getting started


### PR DESCRIPTION
Resolves issue #25

The markup version of the readme that is displayed for the main page in this repo contains the following bad links:

Status code [404:NotFound] - Link: https://github.com/nasa/Kamodo/blob/master/notebooks/images/fig2d-usage.svg

![image](https://user-images.githubusercontent.com/16634034/101935790-80cf2a80-3bd7-11eb-942e-445b1a9b3456.png)

It should be "https://github.com/nasa/Kamodo/blob/master/docs/notebooks/images/fig2d-usage.svg"


"Introduction"
Status code [404:NotFound] - Link: https://github.com/nasa/Kamodo/blob/master/notebooks/Kamodo.ipynb

It should be "https://github.com/nasa/Kamodo/blob/master/docs/notebooks/Kamodo.ipynb"


(The link in the readme’s raw markdown may appear in a different relative format to the links above)

--

**Extra**


Theses bad links were found by a tool I recently created as part of an new experimental hobby project: https://github.com/MrCull/GitHub-Repo-ReadMe-Dead-Link-Finder
I (a human) verified that this link is broken and have manually logged this Issue (i.e. this Issue has not been created by a bot).
If this has been in any way helpful then please consider giving the above Repo a Star.

If you have any feedback on the information provided here, or on the tool itself, then please feel free to share your thoughts here, or log an “Issue” in the repo.

--


Re-check this Repo via: http://githubreadmechecker.com/Home/Search?SingleRepoUri=https%3a%2f%2fgithub.com%2fnasa%2fKamodo
Check all Repos for this GitHub account: http://githubreadmechecker.com/Home/Search?User=nasa