### PR TITLE
Kamodo C++/plasmapy updates

### DIFF
--- a/kamodo.py
+++ b/kamodo.py
@@ -1,0 +1,1124 @@
+"""
+Copyright 2017 United States Government as represented by the Administrator, National Aeronautics and Space Administration.  
+No Copyright is claimed in the United States under Title 17, U.S. Code.  All Other Rights Reserved.
+"""
+
+import numpy as np
+from sympy import Integral, Symbol, symbols, Function
+from inspect import signature
+
+try:
+    from sympy.parsing.sympy_parser import parse_expr
+except ImportError:  # may occur for certain versions of sympy
+    from sympy import sympify as parse_expr
+
+from collections import OrderedDict
+from collections import UserDict
+import collections
+
+from sympy import lambdify
+from sympy.parsing.latex import parse_latex
+from sympy import latex
+from sympy.core.function import UndefinedFunction
+from sympy import Eq
+import pandas as pd
+# from IPython.display import Latex
+
+
+from sympy.physics import units as sympy_units
+from sympy.physics.units import Quantity
+from sympy.physics.units import Dimension
+from sympy import Expr
+
+import functools
+from util import kamodofy
+from util import sort_symbols
+from util import simulate
+from util import unit_subs
+from util import get_defaults, valid_args, eval_func
+# from util import to_arrays, cast_0_dim
+from util import beautify_latex, arg_to_latex
+from util import concat_solution
+from util import convert_to
+from util import unify, get_abbrev, get_expr_unit
+from util import is_function, get_arg_units
+
+import sympy.physics.units as u
+
+import plotly.graph_objs as go
+from plotly import figure_factory as ff
+
+from plotting import plot_dict, get_arg_shapes, get_plot_key
+from util import existing_plot_types
+from util import get_dimensions
+from util import reserved_names
+
+from sympy import Wild
+from types import GeneratorType
+import inspect
+
+import re
+
+import urllib.request, json
+import requests
+from util import serialize, deserialize
+from util import sign_defaults
+import forge
+
+
+
+def get_unit_quantities():
+    """returns a map of sympy units {symbol: quantity} """
+    subs = {}
+    for k, v in list(sympy_units.__dict__.items()):
+        if isinstance(v, Expr) and v.has(sympy_units.Unit):
+            subs[Symbol(k)] = v  # Map the `Symbol` for a unit to the quantity
+    return subs
+
+
+def clean_unit(unit_str):
+    """remove brackets and all white spaces in and around unit string"""
+    return unit_str.strip().strip('[]').strip()
+
+
+def get_unit(unit_str, unit_subs=unit_subs):
+    """get the unit quantity corresponding to this string
+
+    unit_subs should contain a dictonary {symbol: quantity} of custom units not available in sympy"""
+
+    unit_str = clean_unit(unit_str)
+    units = get_unit_quantities()
+
+    if unit_subs is not None:
+        units.update(unit_subs)
+
+    if len(unit_str) == 0:
+        return Dimension(1)
+    try:
+        unit = parse_expr(unit_str.replace('^', '**')).subs(units)
+    except:
+        raise NameError('something wrong with unit str [{}], type {}'.format(unit_str, type(unit_str)))
+    try:
+        assert len(unit.free_symbols) == 0
+    except:
+        raise NameError("Unsupported unit: {} {} {}".format(
+            unit_str, type(unit_str), unit.free_symbols))
+    return unit
+
+
+
+
+def args_from_dict(expr, local_dict, verbose):
+    """retrieve the symbols of an expression
+
+    if a  {str: symbol} mapping is provided, use its symbols instead
+    """
+    args = []
+    # if local_dict is not None:
+    if verbose:
+        print('args_from_dict: available names {}'.format(local_dict.keys()))
+    for a in expr.args:
+        if verbose:
+            print('args_from_dict: {}'.format(a))
+        if str(a) in local_dict:
+            args.append(local_dict[str(a)])
+        else:
+            args.append(a)
+    return tuple(args)
+    # else:
+    #     return expr.args
+
+def get_str_units(bracketed_str):
+    """finds all bracketed units in a string
+
+    supports functions like
+        bracketed_str = 'f(x[m],y[cm**3],z[km^.5],q[(cm*g)^-3])[km/s]'
+        get_str_units(bracketed_str)
+        >>> ['m', 'cm**3', 'km^.5', '(cm*g)^-3', 'km/s']
+    """
+    return re.findall(r"\[([A-Za-z0-9_/*^\\(\\)-\.]+)\]", bracketed_str)
+
+def str_has_arguments(func_str): 
+    bracket = func_str.find('[')
+    paren = func_str.find('(')
+    if bracket > 0:
+        if paren > 0:
+            # f(x[(cm)^2]) has arguments since paren comes first
+            # f[(cm)^2] has no arguments since bracket comes first
+            return bracket > paren
+        return False # no paren hence no arguments
+    # no bracket
+    if paren > 0:
+        # has argument
+        return True
+    return False
+
+
+def extract_units(func_str):
+    """separate the units from the left-hand-side of an expression assuming bracket notation
+
+    We return symbol and dictionary mapping symbols to units
+
+    needs to handle the following cases:
+
+        args and output have units
+            extract_units('f(x[cm],y[km])[kg]')
+            ('f(x,y)', {'x': 'cm', 'y': 'km', 'f(x,y)': 'kg'})
+
+        args have parenthesis in units and output has no units
+            extract_units('f(x[(cm )^2])')
+            ('f(x)', {'x': '(cm)^2', 'f(x)': ''})
+
+        output has parenthesis in units
+            extract_units('f[(cm)^2]')
+            ('f', {'f': '(cm)^2'})
+
+        no args named and no units named
+            ('f', {'f': ''})
+
+    """
+    # remove any spaces
+    func_str = func_str.replace(' ', '')
+    all_units = get_str_units(func_str)
+
+    unit_dict = {}
+    if str_has_arguments(func_str):
+        # f(x[cm],y[km])[kg] -> x[cm],y[km]
+        lhs_args = re.findall(r"\((.+)\)", func_str)[0]
+
+        # 'x[cm],y[km]' -> ['cm', 'km']
+        arg_units = get_str_units(lhs_args)
+        args = lhs_args.split(',')
+
+        for arg, unit in zip(args, arg_units):
+            unit_dict[arg.replace('[{}]'.format(unit), '')] = unit
+
+        if len(all_units) == len(arg_units):
+            output_units = ''
+        else:
+            output_units = all_units[-1]
+    else:
+        if len(all_units) > 0:
+            output_units = all_units[0]
+        else:
+            output_units = ''
+
+
+    # f(x[cm],y[km])[kg]
+    lhs = func_str
+    for unit in all_units:
+        lhs = lhs.replace('[{}]'.format(unit), '')
+
+    unit_dict[lhs] = output_units
+    return lhs, unit_dict
+
+
+def expr_to_symbol(expr, args):
+    """f,args -> f(args) of class function, f(x) -> f(x)"""
+    if type(expr) == Symbol:
+        return parse_expr(str(expr) + str(args))
+        # return symbols(str(expr), cls = Function)
+    else:
+        return expr
+
+
+def parse_lhs(lhs, local_dict, verbose):
+    """parse the left-hand-side
+
+    returns: symbol, arguments, units, parsed_expr
+    """
+    lhs, unit_dict = extract_units(lhs)
+    if lhs in reserved_names:
+        raise NameError('{} is a reserved name'.format(lhs))
+    parsed = parse_expr(lhs)
+    args = args_from_dict(parsed, local_dict, verbose)
+    symbol = expr_to_symbol(parsed, args)
+    return symbol, args, unit_dict, parsed
+
+
+def parse_rhs(rhs, is_latex, local_dict):
+    """parse the right-hand-side of an equation
+
+    subsititute variables from local_dict where available
+    """
+    if is_latex:
+        expr = parse_latex(rhs).subs(local_dict)
+    else:
+        try:
+            expr = parse_expr(rhs).subs(local_dict)
+        except SyntaxError:
+            print('cannot parse {} with {}'.format(rhs, local_dict))
+            raise
+    return expr
+
+
+def get_function_args(func, hidden_args=[]):
+    """converts function arguments to list of symbols"""
+    
+    return symbols([a for a in signature(func).parameters if a not in hidden_args])
+
+
+
+
+# class Kamodo(collections.OrderedDict):
+class Kamodo(UserDict):
+    '''Kamodo base class demonstrating common API for space weather models
+
+
+    This API provides access to space weather fields and their properties through:
+
+        interpolation of variables at user-defined points
+        unit conversions
+        coordinate transformations specific to space weather domains
+
+    Required methods that have not been implemented in child classes
+    will raise a NotImplementedError
+    '''
+
+    def __init__(self, *funcs, **kwargs):
+        """Base initialization method
+
+        Args:
+            param1 (str, optional): Filename of datafile to interpolate from
+
+        """
+
+        super(Kamodo, self).__init__()
+        self.symbol_registry = OrderedDict()
+        self.unit_registry = OrderedDict()
+
+        symbol_dict = kwargs.pop('symbol_dict', None)
+
+        self.verbose = kwargs.pop('verbose', False)
+        self.signatures = OrderedDict()
+
+        for func in funcs:
+            if self.verbose:
+                print('registering {}'.format(func))
+            if type(func) is str:
+                components = func.split('=')
+                if len(components) == 2:
+                    # function(arg)[unit] = expr
+                    lhs, rhs = components
+                    self[lhs.strip('$')] = rhs
+                else:
+                    raise NotImplementedError(
+                        'cannot register functions of the form {}'.format(func))
+
+        for sym_name, expr in list(kwargs.items()):
+            if self.verbose:
+                print('registering {} with {}'.format(sym_name, expr))
+            self[sym_name] = expr
+
+
+    def register_symbol(self, symbol):
+        self.symbol_registry[str(type(symbol))] = symbol
+
+
+    # def remove_symbol(self, sym_name):
+    #     """remove the sym_name (str) from the object"""
+
+    #     if self.verbose:
+    #         print('remove_symbol: removing {} from symbol_registry'.format(sym_name))
+    #     try:
+    #         symbol = self.symbol_registry.pop(sym_name)
+    #     except KeyError:
+    #         raise KeyError('{} was not in symbol_registry {}'.format(
+    #             sym_name, self.symbol_registry.keys()))
+    #     if self.verbose:
+    #         print('remove_symbol: removing {} from signatures'.format(symbol))
+    #     self.signatures.pop(str(type(symbol)))
+    #     if self.verbose:
+    #         print('remove_symbol: removing {} from unit_registry'.format(symbol))
+    #     remove = []
+    #     for sym in self.unit_registry:
+    #         if is_function(sym): # {rho(x): rho(cm), rho(cm): kg}
+    #             if type(sym) == type(symbol):
+    #                 remove.append(sym)
+    #     for sym in remove:
+    #         self.unit_registry.pop(sym)
+
+    #     if self.verbose:
+    #         print('removing {} from {}'.format(symbol, self.keys()))
+
+    #     if symbol in self.keys():
+    #         try:
+    #             self.pop(symbol)
+    #         except KeyError:
+    #             if self.verbose:
+    #                 print('something wrong with {} in {}'.format(symbol, self.keys()))
+    #             raise KeyError('{} not in {}'.format(symbol, self.keys()))
+
+    #     if type(symbol) in self.keys():
+    #         try:
+    #             self.pop(type(symbol))
+    #         except KeyError:
+    #             raise KeyError('{} not in {}'.format(type(symbol), self.keys()))
+
+
+    def parse_key(self, sym_name):
+        """parses the symbol name
+
+        sym_name must be a string
+
+        returns: symbol, args, unit_dict, lhs_expr
+        """
+        args = tuple()
+        try:
+            symbol, args, unit_dict, lhs_expr = parse_lhs(
+                sym_name,
+                self.symbol_registry,
+                self.verbose)
+        except:
+            raise NotImplementedError('could not parse key {}'.format(sym_name))
+
+        # try:
+        if len(args) > 0:
+            symbol_str = str(symbol).replace(' ', '')
+        else:
+            symbol_str = str(type(symbol))
+        units = get_abbrev(unit_dict[symbol_str])
+        # except KeyError:
+        #     raise KeyError('{} not in {}'.format(symbol_str, unit_dict))
+
+        return symbol, args, units, lhs_expr
+
+    def parse_value(self, rhs_expr, local_dict):
+        """returns an expression from string"""
+        if type(rhs_expr) is str:
+            is_latex = '$' in rhs_expr
+            rhs_expr = rhs_expr.strip('$').strip()
+            rhs_expr = parse_rhs(rhs_expr, is_latex, local_dict)
+        return rhs_expr
+
+    def check_or_replace_symbol(self, symbol, free_symbols, rhs_expr=None):
+        """Rules of replacement:
+
+        """
+        if self.verbose:
+            print('symbol arguments: >>> {} {} <<<'.format(symbol.args, type(symbol.args)))
+            print('free_symbols: >>> {} {} <<<'.format(free_symbols, type(free_symbols)))
+        # try:
+        lhs_args = set(symbol.args)
+        # except TypeError:
+        #     lhs_args = free_symbols
+        #     symbol = Function(str(symbol))(*lhs_args)
+
+        if lhs_args != set(free_symbols):
+            free_symbols_ = tuple(free_symbols)
+            if len(free_symbols) == 1:
+                # try:
+                symbol = parse_expr(str(type(symbol)) + str(free_symbols_))
+                # except:
+                #     raise NotImplementedError('cannot parse', str(type(symbol)) + str(free_symbols_))
+            else:
+                if len(lhs_args) > 0:
+                    raise NameError("Mismatched symbols {} and {}".format(lhs_args, free_symbols))
+                else:
+                    if self.verbose:
+                        print('type of rhs symbols:', type(free_symbols))
+                    # if isinstance(free_symbols, set):
+                    #     free_symbols_ = sort_symbols(free_symbols)
+                    if self.verbose:
+                        print('replacing {} with {}'.format(
+                            symbol, str(type(symbol)) + str(free_symbols_)))
+                    # try:
+                    symbol = parse_expr(str(type(symbol)) + str(free_symbols_))
+                    # except:
+                    #     raise NotImplementedError('cannot parse', str(type(symbol)) + str(free_symbols_))
+
+        return symbol
+
+    def validate_function(self, lhs_expr, rhs_expr):
+        assert lhs_expr.free_symbols == rhs_expr.free_symbols
+
+
+    def vectorize_function(self, symbol, rhs_expr, composition):
+        try:
+            func = lambdify(symbol.args, rhs_expr, modules=['numexpr'])
+            if self.verbose:
+                print('lambda {} = {} labmdified with numexpr'.format(symbol.args, rhs_expr))
+        except: # numexpr not installed
+            func = lambdify(symbol.args, rhs_expr, modules=['numpy', composition])
+            if self.verbose:
+                print('lambda {} = {} lambdified with numpy and composition:'.format(
+                    symbol.args, rhs_expr))
+                for k, v in composition.items():
+                    print('\t', k, v)
+        signature = sign_defaults(symbol, rhs_expr, composition)
+        return signature(func)
+
+
+    def update_unit_registry(self, func, arg_units):
+        """Inserts unit functions into registry"""
+        lhs, unit_dict = extract_units(func)
+        # if arg_units is None:
+        #     arg_units = {}
+        for key, value in unit_dict.items():
+            if key != lhs:
+                arg_units[parse_expr(key)] = get_unit(value)
+
+        lhs_expr = parse_expr(lhs)
+        func_units = lhs_expr.subs(arg_units)
+        self.unit_registry[lhs_expr] = func_units
+        output_units = unit_dict[lhs]
+        self.unit_registry[func_units] = get_unit(output_units)
+        return lhs
+
+
+    def register_signature(self, symbol, units, lhs_expr, rhs_expr):
+        # if isinstance(units, str):
+        unit_str = units
+        if self.verbose:
+            print('unit str {}'.format(unit_str))
+
+        self.signatures[str(type(symbol))] = dict(
+            symbol=symbol,
+            units=unit_str,
+            lhs=lhs_expr,
+            rhs=rhs_expr,
+            # update = getattr(self[lhs_expr],'update', None),
+        )
+
+    def register_function(self, func, lhs_symbol, lhs_expr, lhs_units):
+        hidden_args = []
+        if hasattr(func, 'meta'):
+            hidden_args = func.meta.get('hidden_args', [])
+
+        if type(func) is np.vectorize:
+            rhs_args = get_function_args(func.pyfunc, hidden_args)
+        else:
+            rhs_args = get_function_args(func, hidden_args)
+        if str(rhs_args[0]) == 'self':  # in case function is a class method
+            rhs_args.pop(0)
+
+        lhs_symbol_old = lhs_symbol
+        lhs_symbol = self.check_or_replace_symbol(lhs_symbol, rhs_args)
+        units = lhs_units
+        if hasattr(func, 'meta'):
+            if self.verbose:
+                print('function has metadata', func.meta.keys())
+            if len(lhs_units) > 0:
+                if lhs_units != func.meta['units']:
+                    raise NameError('Units mismatch:{} != {}'.format(lhs_units, func.meta['units']))
+            else:
+                units = func.meta['units']
+            rhs = func.meta.get('equation', func)
+            if self.verbose:
+                print('rhs from meta: {}'.format(rhs))
+        else:
+            rhs = func
+            if self.verbose:
+                print('rhs from input func {}'.format(rhs))
+            try:
+                setattr(func, 'meta', dict(units=lhs_units, arg_units=None))
+            except:  # will not work on bound methods
+                pass
+
+        arg_units = func.meta.get('arg_units', None)
+        if arg_units is not None:
+            unit_dict = {arg: get_unit(arg_unit) for arg, arg_unit in arg_units.items()}
+            unit_expr = lhs_symbol.subs(unit_dict)
+            self.unit_registry[lhs_symbol] = unit_expr
+            self.unit_registry[unit_expr] = get_unit(units)
+        else:
+            self.unit_registry[lhs_symbol] = get_unit(units)
+
+        self.register_signature(lhs_symbol, units, lhs_expr, rhs)
+        try:
+            func._repr_latex_ = lambda: self.func_latex(str(type(lhs_symbol)), mode='inline')
+        except AttributeError:
+            # happens with bound methods
+            pass
+        super(Kamodo, self).__setitem__(lhs_symbol, func)  # assign key 'f(x)'
+        super(Kamodo, self).__setitem__(type(lhs_symbol), self[lhs_symbol])  # assign key 'f'
+        self.register_symbol(lhs_symbol)
+
+
+    def __setitem__(self, sym_name, input_expr):
+        """Assigns a function or expression to a new symbol,
+        performs unit conversion where appropriate
+
+        """
+        if not isinstance(sym_name, str):
+            sym_name = str(sym_name)
+
+        symbol, args, lhs_units, lhs_expr = self.parse_key(sym_name)
+
+        if hasattr(input_expr, '__call__'):
+            self.register_function(input_expr, symbol, lhs_expr, lhs_units)
+
+        else:
+            if self.verbose:
+                print(
+                    "\n\nPARSING WITH UNIFY",
+                    lhs_expr,
+                    symbol,
+                    lhs_units,
+                    len(lhs_units),
+                    type(lhs_units))
+                print('symbol registry:', self.symbol_registry)
+
+            rhs_expr = self.parse_value(input_expr, self.symbol_registry)
+
+            if self.verbose:
+                print('parsed rhs_expr', rhs_expr)
+
+            if not isinstance(symbol, Symbol):
+                if isinstance(lhs_expr, Symbol):
+                    symbol = Function(lhs_expr)(*tuple(rhs_expr.free_symbols))
+                else: #lhs is already a function
+                    symbol = lhs_expr
+                lhs_str = str(symbol)
+                sym_name = sym_name.replace(str(lhs_expr), lhs_str)
+            if self.verbose:
+                print('unit registry contents:')
+                for k, v in self.unit_registry.items():
+                    print('\t', k, type(k), v)
+            if '[' in sym_name:
+                if self.verbose:
+                    print('updating unit registry with {} -> {}'.format(sym_name, rhs_expr))
+                rhs = rhs_expr
+                arg_units = get_arg_units(rhs_expr, self.unit_registry)
+                if self.verbose:
+                    print(arg_units)
+                sym_name = self.update_unit_registry(sym_name, arg_units)
+                if self.verbose:
+                    print('unit registry update returned', sym_name, self.unit_registry.get(symbol))
+            else:
+
+                if self.verbose:
+                    print(sym_name,
+                          symbol,
+                          'had no units. Getting units from {}'.format(rhs_expr))
+
+                expr_unit = get_expr_unit(rhs_expr, self.unit_registry, self.verbose)
+                arg_units = get_arg_units(rhs_expr, self.unit_registry)
+
+
+                if self.verbose:
+                    print('registering {} with {} {}'.format(symbol, expr_unit, arg_units))
+
+                if (symbol not in self.unit_registry) and (expr_unit is not None):
+                    self.unit_registry[symbol] = symbol.subs(arg_units)
+                    self.unit_registry[symbol.subs(arg_units)] = expr_unit
+
+
+                if expr_unit is not None:
+                    expr_dimensions = get_dimensions(expr_unit)
+                    if expr_dimensions != Dimension(1):
+                        lhs_units = str(get_abbrev(get_expr_unit(
+                            expr_unit,
+                            self.unit_registry,
+                            self.verbose)))
+                    else:
+                        lhs_units = ''
+
+                if self.verbose:
+                    print('registered lhs_units', lhs_units)
+
+                rhs = rhs_expr
+                sym_name = str(sym_name)
+
+
+
+            if len(lhs_units) > 0:
+                if self.verbose:
+                    print('about to unify lhs_units {} {} with {}'.format(
+                        lhs_units, type(lhs_units), rhs))
+
+                expr = unify(
+                    Eq(parse_expr(sym_name), rhs),
+                    self.unit_registry,
+                    # to_symbol = symbol,
+                    verbose=self.verbose)
+                rhs_expr = expr.rhs
+
+            if self.verbose:
+                print('symbol after unify', symbol, type(symbol), rhs_expr)
+                print('unit registry to resolve units:', self.unit_registry)
+
+            units = get_expr_unit(symbol, self.unit_registry)
+            if get_dimensions(units) != Dimension(1):
+                units = get_abbrev(units)
+                if units is not None:
+                    units = str(units)
+                else:
+                    units = ''
+            else:
+                units = ''
+
+            if self.verbose:
+                print('units after resolve', symbol, units)
+                for k, v in self.unit_registry.items():
+                    print('\t{}: {}'.format(k, v))
+
+            rhs_args = rhs_expr.free_symbols
+
+            symbol = self.check_or_replace_symbol(symbol, rhs_args, rhs_expr)
+            self.validate_function(symbol, rhs_expr)
+
+            composition = {str(k_): self[k_] for k_ in self}
+            arg_units = {}
+            if symbol in self.unit_registry:
+                unit_args = self.unit_registry[symbol]
+                if unit_args is not None:
+                    if len(unit_args.args) == len(symbol.args):
+                        for arg, unit in zip(symbol.args, unit_args.args):
+                            arg_units[str(arg)] = str(get_abbrev(unit))
+            func = self.vectorize_function(symbol, rhs_expr, composition)
+            meta = dict(units=units, arg_units=arg_units)
+            func.meta = meta
+            func.data = None
+            self.register_signature(symbol, units, lhs_expr, rhs_expr)
+            func._repr_latex_ = lambda: self.func_latex(str(type(symbol)), mode='inline')
+            super(Kamodo, self).__setitem__(symbol, func)
+            super(Kamodo, self).__setitem__(type(symbol), self[symbol])
+            self.register_symbol(symbol)
+
+
+    def __getitem__(self, key):
+        try:
+            return super(Kamodo, self).__getitem__(key)
+        except KeyError:
+            try:
+                symbol = self.symbol_registry[str(key)]
+            except KeyError:
+                symbol = self.symbol_registry[str(type(key))]
+            if symbol in self:
+                return super().__getitem__(symbol)
+
+    def __contains__(self, item):
+        func_str = str(item).replace(' ', '')
+        for key in self.keys():
+            if func_str == str(key).replace(' ', ''):
+                return True
+        return False
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError(name)
+
+    def __delattr__(self, name):
+
+        if name in self:
+            symbol = self.symbol_registry[name]
+            if self.verbose:
+                print('__delattr__: removing name {}, symbol {}'.format(name, symbol))
+                print(self.keys())
+            # del self[symbol]
+            super().pop(symbol)
+            super().pop(type(symbol))
+
+        else:
+            raise AttributeError("No such field: " + name)
+
+    def __delitem__(self, key):
+        if self.verbose:
+            print('__delitem__: got {} type: {}'.format(key, type(key)))
+        if isinstance(key, str):
+            if self.verbose:
+                print('__delitem__: removing {} from symbol_registry'.format(key))
+            symbol = self.symbol_registry.pop(key, None)
+            if symbol is None:
+                symbol, args, unit_dict, parsed = parse_lhs(
+                    key, self.symbol_registry, self.verbose)
+        else:
+            symbol = key
+            if self.verbose:
+                print('__delitem__: received non str key {}'.format(symbol))
+        if self.verbose:
+            print('__delitem__: removing {} {}'.format(symbol, type(symbol)))
+
+
+        remove_keys = []
+        for k in self.data:
+            if str(k) == str(symbol):
+                remove_keys.append(k)
+            if str(k) == str(type(symbol)):
+                remove_keys.append(k)
+        if self.verbose:
+            print('__delitem__: removing keys:', remove_keys)
+
+        for key_ in remove_keys:
+            self.data.pop(key_)
+            self.signatures.pop(str(key_), None)
+            self.signatures.pop(str(type(key_)), None)
+            self.unit_registry.pop(key_, None)
+
+    # def get_units_map(self):
+    #     """Maps from string units to symbolic units"""
+    #     d = dict()
+    #     star = Wild('star')
+    #     for k, v in list(self.signatures.items()):
+    #         unit = get_unit(v['units'])
+    #         d[k] = unit
+    #         d[v['symbol']] = unit
+
+    #     return d
+
+    def func_latex(self, key, mode='equation'):
+        """get a latex string for a given function key"""
+        repr_latex = ""
+        lhs = self.signatures[key]['symbol']
+        rhs = self.signatures[key]['rhs']
+        units = self.signatures[key]['units']
+        arg_units = get_arg_units(lhs, self.unit_registry)
+
+        if len(units) > 0:
+            units = '{}'.format(get_abbrev(units))
+        else:
+            units = ''
+
+        if len(arg_units) > 0:
+            arg_strs = []
+            for arg, arg_unit in arg_units.items():
+                arg_strs.append("{}[{}]".format(
+                    latex(arg),
+                    latex(get_abbrev(arg_unit),
+                        fold_frac_powers=True,
+                        fold_short_frac=True,
+                        root_notation=False,
+                        )))
+            lhs_str = "{}({})".format(latex(type(lhs)), ",".join(arg_strs))
+        else:
+            lhs_str = latex(lhs)
+            # lhs_str = "{}({})".format(
+            #     latex(type(lhs)),
+            #     ','.join([latex(s) for s in lhs.args]))
+
+        if len(units) > 0:
+            lhs_str += "[{}]".format(latex(parse_expr(units),
+                    fold_frac_powers=True,
+                    fold_short_frac=True,
+                    root_notation=False,
+                ))
+
+
+        latex_eq = ''
+        latex_eq_rhs = ''
+
+        if isinstance(rhs, str):
+            latex_eq_rhs = rhs       
+        elif hasattr(rhs, '__call__') | (rhs is None):
+            lambda_ = symbols('lambda', cls=UndefinedFunction)
+            # latex_eq = latex(Eq(lhs, lambda_(*lhs.args)), mode=mode)
+            latex_eq_rhs = latex(lambda_(*lhs.args)) # no $$
+        else:
+            # latex_eq = latex(Eq(lhs, rhs), mode=mode)
+            latex_eq_rhs = latex(rhs) # no $$ delimiter
+
+        if len(str(units)) > 0:
+            latex_eq = latex_eq.replace('=', '[{}] ='.format(units))
+
+        if mode == 'equation':
+            repr_latex += r"\begin{equation}"
+            repr_latex += "{} = {}".format(lhs_str, latex_eq_rhs)
+            repr_latex += r"\end{equation}"
+        else:
+            repr_latex += r"$"
+            repr_latex += "{} = {}".format(lhs_str, latex_eq_rhs)
+            repr_latex += r"$"
+
+        return repr_latex
+
+
+
+    def to_latex(self, keys=None, mode='equation'):
+        """Generate list of LaTeX-formated formulas
+        Upon registeration, each function should have a _repr_latex_ method.
+        """
+        if keys is None:
+            keys = list(self.signatures.keys())
+
+        funcs_latex = []
+        for k in keys:
+            # funcs_latex.append(self.func_latex(k, mode))
+            func_latex = self[k]._repr_latex_()
+            if mode == 'equation':
+                func_latex = func_latex.strip('$')
+                func_latex = r"\begin{equation}" + func_latex + r"\end{equation}"
+            funcs_latex.append(func_latex)
+
+        repr_latex = " ".join(funcs_latex)
+
+        return beautify_latex(repr_latex).encode('utf-8').decode()
+
+    def _repr_latex_(self):
+        """Provide notebook rendering of formulas"""
+        return self.to_latex()
+
+    def detail(self):
+        """Constructs a pandas dataframe from signatures"""
+        return pd.DataFrame(self.signatures).T
+
+
+    def simulate(self, **kwargs):
+        state_funcs = []
+        for name, func_key in list(self.symbol_registry.items()):
+            func = self[func_key]
+            update_var = getattr(func, 'update', None)
+            if update_var is not None:
+                state_funcs.append((func.update, func))
+
+        return simulate(OrderedDict(state_funcs), **kwargs)
+
+    def evaluate(self, variable, *args, **kwargs):
+        """evaluates the variable
+
+        if the variable is not present, try to parse it as a semicolon-delimited list
+        """
+        if not hasattr(self, variable):
+            var_dict = {}
+            for variable_ in variable.split(';'):
+                if len(variable_.split('=')) == 2:
+                    variable_name, variable_expr = variable_.strip("'").split('=')
+                    var_dict[variable_name] = variable_expr
+                else:
+                    raise SyntaxError('cannot parse {}'.format(variable_))
+            knew = from_kamodo(self, **var_dict)
+            # evaluate the last variable
+            result = knew.evaluate(variable=variable_name, *args, **kwargs)
+            return result
+
+
+        if isinstance(self[variable], np.vectorize):
+            params = get_defaults(self[variable].pyfunc)
+        else:
+            params = get_defaults(self[variable])
+
+        valid_arguments = valid_args(self[variable], kwargs)
+        if len(params) > 0:
+            if self.verbose:
+                print('default parameters:', list(params.keys()))
+            params.update(valid_arguments)
+        else:
+            if self.verbose:
+                print('no default parameters')
+            params = valid_arguments
+            if self.verbose:
+                print('user-supplied args:', list(params.keys()))
+        result = eval_func(self[variable], params)
+        if isinstance(result, GeneratorType):
+            params = concat_solution(result, variable)
+        else:
+            params.update({variable: result})
+        return params
+
+    def solve(self, fprime, interval, y0,
+              dense_output=True,  # generate a callable solution
+              events=None,  # stop when event is triggered
+              vectorized=True, ):
+        from scipy.integrate import solve_ivp
+
+        result = solve_ivp(self[fprime], interval, y0,
+                           dense_output=dense_output,
+                           events=events,
+                           vectorized=vectorized)
+        if self.verbose:
+            print(result['message'])
+
+        varname = next(iter(inspect.signature(self[fprime]).parameters.keys()))
+
+        scope = {'result': result, 'varname': varname}
+
+        soln_str = r"""def solution({varname} = result['t']):
+            return result['sol'].__call__({varname}).T.squeeze()""".format(varname=varname)
+
+        exec(soln_str.format(), scope)
+
+        return scope['solution']
+
+    def figure(self, variable, indexing='ij', **kwargs):
+        """Generates a plotly figure for a given variable and keyword arguments"""
+        result = self.evaluate(variable, **kwargs)
+        signature = self.signatures[variable]
+        units = signature['units']
+        if units != '':
+            units = '[{}]'.format(units)
+        title = self.to_latex([variable], 'inline')
+        title_lhs = title.split(' =')[0] + '$'
+        title_short = '{}'.format(variable + units)  # something wrong with colorbar latex being vertical
+        titles = dict(title=title, title_lhs=title_lhs, title_short=title_short, units=units, variable=variable)
+        fig = dict()
+        chart_type = None
+        traces = []
+
+        hidden_args = []
+        if 'hidden_args' in self[variable].meta:
+            hidden_args = self[variable].meta['hidden_args']
+        arg_arrays = [result[k] for k in result if k not in hidden_args][:-1]
+
+        arg_shapes = get_arg_shapes(*arg_arrays)
+
+        out_dim, arg_dims = get_plot_key(result[variable].shape, *arg_shapes)
+
+        try:
+            plot_func = plot_dict[out_dim][arg_dims]['func']
+        except KeyError:
+            print('not supported: out_dim {}, arg_dims {}'.format(out_dim, arg_dims))
+            raise
+
+        traces, chart_type, layout = plot_func(
+            result,
+            titles,
+            indexing=indexing,
+            verbose=self.verbose,
+            **kwargs)
+
+        layout.update(
+            dict(autosize=False,
+                 width=700,
+                 height=400,
+                 margin=go.layout.Margin(
+                     # l=30,
+                     r=30,
+                     b=32,
+                     t=40,
+                     pad=0),
+                 ))
+
+        fig['data'] = traces
+        fig['layout'] = layout
+        return go.Figure(fig).update_traces(meta=chart_type)
+        # if return_type:
+        #     fig['chart_type'] = chart_type
+        # return fig
+
+    def plot(self, *variables, **figures):
+        for k in variables:
+            figures[k] = {}
+        if len(figures) == 1:
+            variable, kwargs = list(figures.items())[0]
+            fig = self.figure(variable, **kwargs)
+            # if fig['chart_type'] is None:
+            #     raise AttributeError("No chart_type for this trace")
+            # else:
+            #     if self.verbose:
+            #         print('chart type:', fig['chart_type'])
+            return go.Figure(
+                data=fig['data'],
+                layout=fig['layout'])
+        else:
+            traces = []
+            layouts = []
+            for variable, kwargs in list(figures.items()):
+                fig = self.figure(variable, **kwargs)
+                traces.extend(fig['data'])
+                layouts.append(fig['layout'])
+            # Todo: merge the layouts instead of selecting the last one
+            return go.Figure(data=traces, layout=layouts[-1])
+
+
+class KamodoAPI(Kamodo):
+    """JSON api wrapper for kamodo services"""
+    def __init__(self, url_path, **kwargs):
+        self._url_path = url_path
+        super(KamodoAPI, self).__init__(**kwargs)
+
+        self._kdata = self._get(self._url_path)
+
+        self._defaults = {}
+        self._data = {}
+
+        self.__doc__ = requests.get('{}/doc'.format(self._url_path)).text
+
+        for k, v in self._kdata.items():
+            # get defaults for this func
+            default_path = '{}/{}/defaults'.format(self._url_path, k)
+            self._defaults[k] = self._get(default_path)
+
+            # get cached data (result of calling with no args)
+            data_path = '{}/{}/data'.format(self._url_path, k)
+            self._data[k] = self._get(data_path)
+
+            doc_path = '{}/{}/doc'.format(self._url_path, k)
+            func_doc = requests.get(doc_path).text
+
+            # get kamodofied function
+            func = self.load_func(k)
+            func.__doc__ += '\n' + func_doc
+            self[k] = kamodofy(
+                func,
+                data=self._data[k],
+                units=v['units'],
+                )
+
+    def _get(self, url_path):
+        req_result = requests.get(url_path)
+        try:
+            result = req_result.json() # returns a dictionary maybe
+        except json.JSONDecodeError as m:
+            print('could not decode request {}'.format(req_result.text))
+            raise json.JSONDecodeError(m)
+
+        if isinstance(result, str):
+            result_dict = json.loads(result, object_hook=deserialize)
+        else:
+            result_dict = result
+        return result_dict
+
+    def _call_func(self, func_name, **kwargs):
+        """construct the url and call api with params"""
+        url_path = '{}/{}'.format(self._url_path, func_name)
+        if self.verbose:
+            print('querying {}'.format(url_path))
+        params = []
+        for k, v in kwargs.items():
+            params.append((k, json.dumps(v, default=serialize)))
+        result = requests.get(
+            url=url_path,
+            params=params).json() #returns a dictionary
+
+        if isinstance(result, str):
+            if self.verbose:
+                print('reloading json as str')
+            result = json.loads(result, object_hook=deserialize)
+        else:
+            result = deserialize(result)
+        return result
+
+    def load_func(self, func_name):
+        """loads a function signature"""
+        signature = []
+        for arg, arg_default in self._defaults[func_name].items():
+            signature.append(forge.arg(arg, default=arg_default))
+
+        @forge.sign(*signature)
+        def api_func(*args, **kwargs):
+            """API function"""
+            return self._call_func(func_name, **kwargs)
+
+        api_func.__name__ = func_name
+        api_func.__doc__ = "{}/{}".format(self._url_path, func_name)
+        return api_func
+
+def compose(**kamodos):
+    """Kamposes multiple kamodo instances into one"""
+    kamodo = Kamodo()
+    for kname, k in kamodos.items():
+        for name, symbol in k.symbol_registry.items():
+            signature = k.signatures[name]
+            meta = k[symbol].meta
+            data = getattr(k[symbol], 'data', None)
+
+            rhs = signature['rhs']
+            registry_name = '{}_{}'.format(name, kname)
+            if (rhs is None) | hasattr(rhs, '__call__'):
+                kamodo[registry_name] = kamodofy(k[symbol], data=data, **meta)
+            else:
+                kamodo[registry_name] = str(rhs)
+
+    return kamodo
+
+def from_kamodo(kobj, **funcs):
+    """copies a kamodo object, inserting additional functions"""
+    knew = Kamodo()
+    for name, signature in kobj.signatures.items():
+        symbol = signature['symbol']
+        knew[symbol] = kobj[symbol]
+    for symbol, func in funcs.items():
+        knew[symbol] = func
+    return knew

--- a/kamodo/__init__.py
+++ b/kamodo/__init__.py
@@ -1,4 +1,4 @@
 import os, sys; sys.path.append(os.path.dirname(os.path.realpath(__file__)))
-from kamodo.kamodo import *
-from kamodo.util import *
+from kamodo import *
+from util import *
 

--- a/kamodo/kamodo.py
+++ b/kamodo/kamodo.py
@@ -1,5 +1,5 @@
 """
-Copyright © 2017 United States Government as represented by the Administrator, National Aeronautics and Space Administration.  
+Copyright 2017 United States Government as represented by the Administrator, National Aeronautics and Space Administration.  
 No Copyright is claimed in the United States under Title 17, U.S. Code.  All Other Rights Reserved.
 """
 
@@ -31,17 +31,17 @@ from sympy.physics.units import Dimension
 from sympy import Expr
 
 import functools
-from .util import kamodofy
-from .util import sort_symbols
-from .util import simulate
-from .util import unit_subs
-from .util import get_defaults, valid_args, eval_func
-# from .util import to_arrays, cast_0_dim
-from .util import beautify_latex, arg_to_latex
-from .util import concat_solution
-from .util import convert_to
-from .util import unify, get_abbrev, get_expr_unit
-from .util import is_function, get_arg_units
+from util import kamodofy
+from util import sort_symbols
+from util import simulate
+from util import unit_subs
+from util import get_defaults, valid_args, eval_func
+# from util import to_arrays, cast_0_dim
+from util import beautify_latex, arg_to_latex
+from util import concat_solution
+from util import convert_to
+from util import unify, get_abbrev, get_expr_unit
+from util import is_function, get_arg_units
 
 import sympy.physics.units as u
 
@@ -49,9 +49,9 @@ import plotly.graph_objs as go
 from plotly import figure_factory as ff
 
 from plotting import plot_dict, get_arg_shapes, get_plot_key
-from .util import existing_plot_types
-from .util import get_dimensions
-from .util import reserved_names
+from util import existing_plot_types
+from util import get_dimensions
+from util import reserved_names
 
 from sympy import Wild
 from types import GeneratorType

--- a/kamodo/kamodo.py
+++ b/kamodo/kamodo.py
@@ -5,6 +5,7 @@ No Copyright is claimed in the United States under Title 17, U.S. Code.  All Oth
 
 import numpy as np
 from sympy import Integral, Symbol, symbols, Function
+from inspect import signature
 
 try:
     from sympy.parsing.sympy_parser import parse_expr
@@ -19,7 +20,6 @@ from sympy import lambdify
 from sympy.parsing.latex import parse_latex
 from sympy import latex
 from sympy.core.function import UndefinedFunction
-from inspect import getfullargspec
 from sympy import Eq
 import pandas as pd
 # from IPython.display import Latex
@@ -44,6 +44,7 @@ from util import unify, get_abbrev, get_expr_unit
 from util import is_function, get_arg_units
 
 import sympy.physics.units as u
+from astropy import units as astropyu
 
 import plotly.graph_objs as go
 from plotly import figure_factory as ff
@@ -58,6 +59,12 @@ from types import GeneratorType
 import inspect
 
 import re
+
+import urllib.request, json
+import requests
+from util import serialize, deserialize
+from util import sign_defaults
+import forge
 
 
 
@@ -74,13 +81,23 @@ def clean_unit(unit_str):
     """remove brackets and all white spaces in and around unit string"""
     return unit_str.strip().strip('[]').strip()
 
+#new alternative way to include new units in kamodo when not hardcoded
+def decompose_unit(old_unit):
+    '''If sympy doesn't recognize the unit, try decomposing it.'''
+
+    old_unit = astropyu.Unit(old_unit).decompose().to_string('ogip')
+    unit_list = [(' / ','/'),(' * ','*'),(' ','*')]  #cannot accept spaces from astropy
+    for old, new in unit_list: old_unit = old_unit.replace(old,new)
+    
+    return old_unit #string
 
 def get_unit(unit_str, unit_subs=unit_subs):
     """get the unit quantity corresponding to this string
 
     unit_subs should contain a dictonary {symbol: quantity} of custom units not available in sympy"""
 
-    unit_str = clean_unit(unit_str)
+    unit_str = clean_unit(unit_str).replace('^', '**')
+    if 'radian' not in unit_str: unit_str = unit_str.replace('rad','radian') #sympy doesn't recognize rad
     units = get_unit_quantities()
 
     if unit_subs is not None:
@@ -88,10 +105,15 @@ def get_unit(unit_str, unit_subs=unit_subs):
 
     if len(unit_str) == 0:
         return Dimension(1)
-    try:
-        unit = parse_expr(unit_str.replace('^', '**')).subs(units)
-    except:
-        raise NameError('something wrong with unit str [{}], type {}'.format(unit_str, type(unit_str)))
+    if not hasattr(parse_expr(unit_str),'subs'):  #if not in sympy dictionary
+        unit_str = decompose_unit(unit_str)   #decompose with astropy
+    if hasattr(parse_expr(unit_str),'subs'):  #for both corrected/original versions
+        #print(unit_str, type(unit_str))
+        unit = parse_expr(unit_str).subs(units)
+        #print(unit, type(unit))
+    else:  #error if still didn't work
+        raise NameError('something wrong with unit str [{}], type {}'.format(
+            unit_str, type(unit_str)))
     try:
         assert len(unit.free_symbols) == 0
     except:
@@ -248,7 +270,8 @@ def parse_rhs(rhs, is_latex, local_dict):
 
 def get_function_args(func, hidden_args=[]):
     """converts function arguments to list of symbols"""
-    return symbols([a for a in getfullargspec(func).args if a not in hidden_args])
+    
+    return symbols([a for a in signature(func).parameters if a not in hidden_args])
 
 
 
@@ -425,17 +448,6 @@ class Kamodo(UserDict):
     def validate_function(self, lhs_expr, rhs_expr):
         assert lhs_expr.free_symbols == rhs_expr.free_symbols
 
-    # def get_composition(self, lhs_expr, rhs_expr):
-    #     composition = dict()
-    #     for k in list(self.keys()):
-    #         if len(rhs_expr.find(k)) > 0:
-    #             if self.verbose:
-    #                 print('composition detected: found {} in {} = {}'.format(k, lhs_expr, rhs_expr))
-    #             composition[str(k)] = self[k]
-    #         else:
-    #             if self.verbose:
-    #                 print('{} {} not in {} = {}'.format(k, type(k), lhs_expr, rhs_expr))
-    #     return composition
 
     def vectorize_function(self, symbol, rhs_expr, composition):
         try:
@@ -449,7 +461,9 @@ class Kamodo(UserDict):
                     symbol.args, rhs_expr))
                 for k, v in composition.items():
                     print('\t', k, v)
-        return func
+        signature = sign_defaults(symbol, rhs_expr, composition)
+        return signature(func)
+
 
     def update_unit_registry(self, func, arg_units):
         """Inserts unit functions into registry"""
@@ -473,14 +487,7 @@ class Kamodo(UserDict):
         unit_str = units
         if self.verbose:
             print('unit str {}'.format(unit_str))
-        # else:
-        #     if self.verbose:
-        #         print('getting abbreviation for', units)
-        #     unit_abbrev = get_abbrev(units)
-        #     if unit_abbrev is not None:
-        #         unit_str = str(unit_abbrev)
-        #     else:
-        #         unit_str = None
+
         self.signatures[str(type(symbol))] = dict(
             symbol=symbol,
             units=unit_str,
@@ -532,53 +539,17 @@ class Kamodo(UserDict):
             self.unit_registry[unit_expr] = get_unit(units)
         else:
             self.unit_registry[lhs_symbol] = get_unit(units)
-        super(Kamodo, self).__setitem__(lhs_symbol, func)  # assign key 'f(x)'
+
         self.register_signature(lhs_symbol, units, lhs_expr, rhs)
+        try:
+            func._repr_latex_ = lambda: self.func_latex(str(type(lhs_symbol)), mode='inline')
+        except AttributeError:
+            # happens with bound methods
+            pass
+        super(Kamodo, self).__setitem__(lhs_symbol, func)  # assign key 'f(x)'
         super(Kamodo, self).__setitem__(type(lhs_symbol), self[lhs_symbol])  # assign key 'f'
         self.register_symbol(lhs_symbol)
 
-    # def check_consistency(self, input_expr, units):
-    #     # check that rhs units are consistent
-    #     rhs_expr = self.parse_value(input_expr, self.symbol_registry)
-    #     units_map = self.get_units_map()
-    #     lhs_units = get_unit(units)
-    #     rhs_units = validate_units(rhs_expr, units_map, self.verbose)
-    #     if self.verbose:
-    #         print('rhs_units: {}'.format(rhs_units))
-    #     try:
-    #         lhs_units, rhs_units = match_dimensionless_units(lhs_units, rhs_units)
-    #         check_unit_compatibility(rhs_units, lhs_units)
-    #     except:
-    #         print(type(rhs_units))
-    #         print(get_unit(units), validate_units(rhs_expr, units_map, self.verbose))
-    #         raise
-
-    #     rhs_expr_with_units = get_expr_with_units(rhs_expr, units_map)
-
-    #     if self.verbose:
-    #         print('rhs_expr with units:', rhs_expr_with_units)
-
-    #     # convert back to expression without units for lambdify
-    #     if units != '':
-    #         try:
-    #             if self.verbose:
-    #                 print('converting to {}'.format(lhs_units))
-    #                 for k, v in list(units_map.items()):
-    #                     print('\t', k, v, type(k))
-    #             rhs_expr = get_expr_without_units(
-    #                 rhs_expr_with_units,
-    #                 lhs_units,
-    #                 units_map,
-    #                 dimensionless=is_dimensionless(rhs_units))
-    #             if self.verbose:
-    #                 print('rhs_expr without units:', rhs_expr)
-    #         except:
-    #             print('error with units? [{}]'.format(units))
-    #             raise
-    #     else:
-    #         if lhs_units != Dimension(1):  # lhs_units were obtained from rhs_units
-    #             units = str(lhs_units)
-    #     return units, rhs_expr
 
     def __setitem__(self, sym_name, input_expr):
         """Assigns a function or expression to a new symbol,
@@ -589,20 +560,6 @@ class Kamodo(UserDict):
             sym_name = str(sym_name)
 
         symbol, args, lhs_units, lhs_expr = self.parse_key(sym_name)
-
-        # if self.verbose:
-        #     print('')
-        # try:
-        #     symbol, args, lhs_units, lhs_expr = self.parse_key(sym_name)
-        # except KeyError as error:
-        #     if self.verbose:
-        #         print('could not use parse_key with {}'.format(sym_name))
-        #         print(error)
-        #     found_sym_name = str(error).split('found')[0].strip("'").strip(' ')
-        #     if self.verbose:
-        #         print('__setitem__: replacing {}'.format(found_sym_name))
-        #     self.remove_symbol(found_sym_name)
-        #     symbol, args, lhs_units, lhs_expr = self.parse_key(sym_name)
 
         if hasattr(input_expr, '__call__'):
             self.register_function(input_expr, symbol, lhs_expr, lhs_units)
@@ -645,11 +602,7 @@ class Kamodo(UserDict):
                 if self.verbose:
                     print('unit registry update returned', sym_name, self.unit_registry.get(symbol))
             else:
-                # if symbol in self.unit_registry:
-                #     units = get_expr_unit(symbol, self.unit_registry)
-                #     if self.verbose:
-                #         print('{} has units {}'.format(sym_name, units))
-                # else:
+
                 if self.verbose:
                     print(sym_name,
                           symbol,
@@ -658,8 +611,6 @@ class Kamodo(UserDict):
                 expr_unit = get_expr_unit(rhs_expr, self.unit_registry, self.verbose)
                 arg_units = get_arg_units(rhs_expr, self.unit_registry)
 
-                # if expr_unit == Dimension(1):
-                #     expr_unit = None
 
                 if self.verbose:
                     print('registering {} with {} {}'.format(symbol, expr_unit, arg_units))
@@ -668,16 +619,14 @@ class Kamodo(UserDict):
                     self.unit_registry[symbol] = symbol.subs(arg_units)
                     self.unit_registry[symbol.subs(arg_units)] = expr_unit
 
-                # if is_function(expr_unit):
-                #     self.unit_registry[expr_unit] = get_expr_unit(
-                #         expr_unit,
-                #         self.unit_registry,
-                #         self.verbose)
 
                 if expr_unit is not None:
                     expr_dimensions = get_dimensions(expr_unit)
                     if expr_dimensions != Dimension(1):
-                        lhs_units = str(get_abbrev(get_expr_unit(expr_unit, self.unit_registry, self.verbose)))
+                        lhs_units = str(get_abbrev(get_expr_unit(
+                            expr_unit,
+                            self.unit_registry,
+                            self.verbose)))
                     else:
                         lhs_units = ''
 
@@ -722,19 +671,9 @@ class Kamodo(UserDict):
 
             rhs_args = rhs_expr.free_symbols
 
-            # try:
             symbol = self.check_or_replace_symbol(symbol, rhs_args, rhs_expr)
             self.validate_function(symbol, rhs_expr)
-            # except:
-            #     if self.verbose:
-            #         print('\n Error in __setitem__', input_expr)
-            #         print(symbol, lhs_expr, rhs_args)
-            #         print('symbol registry:', self.symbol_registry)
-            #         print('signatures:', self.signatures)
-            #         print('unit registry:', self.unit_registry)
-            #     raise
 
-            # composition = self.get_composition(lhs_expr, rhs_expr)
             composition = {str(k_): self[k_] for k_ in self}
             arg_units = {}
             if symbol in self.unit_registry:
@@ -748,10 +687,10 @@ class Kamodo(UserDict):
             func.meta = meta
             func.data = None
             self.register_signature(symbol, units, lhs_expr, rhs_expr)
+            func._repr_latex_ = lambda: self.func_latex(str(type(symbol)), mode='inline')
             super(Kamodo, self).__setitem__(symbol, func)
             super(Kamodo, self).__setitem__(type(symbol), self[symbol])
             self.register_symbol(symbol)
-            # self[symbol].meta = dict(units=units)
 
 
     def __getitem__(self, key):
@@ -796,15 +735,19 @@ class Kamodo(UserDict):
         if self.verbose:
             print('__delitem__: got {} type: {}'.format(key, type(key)))
         if isinstance(key, str):
-            try:
-                symbol = self.symbol_registry[key]
-            except KeyError:
+            if self.verbose:
+                print('__delitem__: removing {} from symbol_registry'.format(key))
+            symbol = self.symbol_registry.pop(key, None)
+            if symbol is None:
                 symbol, args, unit_dict, parsed = parse_lhs(
                     key, self.symbol_registry, self.verbose)
         else:
             symbol = key
+            if self.verbose:
+                print('__delitem__: received non str key {}'.format(symbol))
         if self.verbose:
             print('__delitem__: removing {} {}'.format(symbol, type(symbol)))
+
 
         remove_keys = []
         for k in self.data:
@@ -817,6 +760,9 @@ class Kamodo(UserDict):
 
         for key_ in remove_keys:
             self.data.pop(key_)
+            self.signatures.pop(str(key_), None)
+            self.signatures.pop(str(type(key_)), None)
+            self.unit_registry.pop(key_, None)
 
     # def get_units_map(self):
     #     """Maps from string units to symbolic units"""
@@ -830,6 +776,7 @@ class Kamodo(UserDict):
     #     return d
 
     def func_latex(self, key, mode='equation'):
+        """get a latex string for a given function key"""
         repr_latex = ""
         lhs = self.signatures[key]['symbol']
         rhs = self.signatures[key]['rhs']
@@ -844,7 +791,13 @@ class Kamodo(UserDict):
         if len(arg_units) > 0:
             arg_strs = []
             for arg, arg_unit in arg_units.items():
-                arg_strs.append("{}[{}]".format(latex(arg), get_abbrev(arg_unit)))
+                arg_strs.append("{}[{}]".format(
+                    latex(arg),
+                    latex(get_abbrev(arg_unit),
+                        fold_frac_powers=True,
+                        fold_short_frac=True,
+                        root_notation=False,
+                        )))
             lhs_str = "{}({})".format(latex(type(lhs)), ",".join(arg_strs))
         else:
             lhs_str = latex(lhs)
@@ -853,7 +806,12 @@ class Kamodo(UserDict):
             #     ','.join([latex(s) for s in lhs.args]))
 
         if len(units) > 0:
-            lhs_str += "[{}]".format(units)
+            lhs_str += "[{}]".format(latex(parse_expr(units),
+                    fold_frac_powers=True,
+                    fold_short_frac=True,
+                    root_notation=False,
+                ))
+
 
         latex_eq = ''
         latex_eq_rhs = ''
@@ -871,21 +829,36 @@ class Kamodo(UserDict):
         if len(str(units)) > 0:
             latex_eq = latex_eq.replace('=', '[{}] ='.format(units))
 
+        if mode == 'equation':
+            repr_latex += r"\begin{equation}"
+            repr_latex += "{} = {}".format(lhs_str, latex_eq_rhs)
+            repr_latex += r"\end{equation}"
+        else:
+            repr_latex += r"$"
+            repr_latex += "{} = {}".format(lhs_str, latex_eq_rhs)
+            repr_latex += r"$"
 
-        repr_latex += r"\begin{equation}"
-        repr_latex += "{} = {}".format(lhs_str, latex_eq_rhs)
-        repr_latex += r"\end{equation}"
         return repr_latex
 
 
 
     def to_latex(self, keys=None, mode='equation'):
-        """Generate list of LaTeX-formated formulas"""
+        """Generate list of LaTeX-formated formulas
+        Upon registeration, each function should have a _repr_latex_ method.
+        """
         if keys is None:
             keys = list(self.signatures.keys())
-        repr_latex = ""
+
+        funcs_latex = []
         for k in keys:
-            repr_latex += self.func_latex(k, mode)
+            # funcs_latex.append(self.func_latex(k, mode))
+            func_latex = self[k]._repr_latex_()
+            if mode == 'equation':
+                func_latex = func_latex.strip('$')
+                func_latex = r"\begin{equation}" + func_latex + r"\end{equation}"
+            funcs_latex.append(func_latex)
+
+        repr_latex = " ".join(funcs_latex)
 
         return beautify_latex(repr_latex).encode('utf-8').decode()
 
@@ -974,14 +947,14 @@ class Kamodo(UserDict):
 
         return scope['solution']
 
-    def figure(self, variable, indexing='ij', return_type=False, **kwargs):
+    def figure(self, variable, indexing='ij', **kwargs):
         """Generates a plotly figure for a given variable and keyword arguments"""
         result = self.evaluate(variable, **kwargs)
         signature = self.signatures[variable]
         units = signature['units']
         if units != '':
             units = '[{}]'.format(units)
-        title = self.to_latex([variable])
+        title = self.to_latex([variable], 'inline')
         title_lhs = title.split(' =')[0] + '$'
         title_short = '{}'.format(variable + units)  # something wrong with colorbar latex being vertical
         titles = dict(title=title, title_lhs=title_lhs, title_short=title_short, units=units, variable=variable)
@@ -1025,22 +998,25 @@ class Kamodo(UserDict):
 
         fig['data'] = traces
         fig['layout'] = layout
-        if return_type:
-            fig['chart_type'] = chart_type
-        return fig
+        return go.Figure(fig).update_traces(meta=chart_type)
+        # if return_type:
+        #     fig['chart_type'] = chart_type
+        # return fig
 
     def plot(self, *variables, **figures):
         for k in variables:
             figures[k] = {}
         if len(figures) == 1:
             variable, kwargs = list(figures.items())[0]
-            fig = self.figure(variable, return_type=True, **kwargs)
-            if fig['chart_type'] is None:
-                raise AttributeError("No chart_type for this trace")
-            else:
-                if self.verbose:
-                    print('chart type:', fig['chart_type'])
-                return go.Figure(data=fig['data'], layout=fig['layout'])
+            fig = self.figure(variable, **kwargs)
+            # if fig['chart_type'] is None:
+            #     raise AttributeError("No chart_type for this trace")
+            # else:
+            #     if self.verbose:
+            #         print('chart type:', fig['chart_type'])
+            return go.Figure(
+                data=fig['data'],
+                layout=fig['layout'])
         else:
             traces = []
             layouts = []
@@ -1051,6 +1027,89 @@ class Kamodo(UserDict):
             # Todo: merge the layouts instead of selecting the last one
             return go.Figure(data=traces, layout=layouts[-1])
 
+
+class KamodoAPI(Kamodo):
+    """JSON api wrapper for kamodo services"""
+    def __init__(self, url_path, **kwargs):
+        self._url_path = url_path
+        super(KamodoAPI, self).__init__(**kwargs)
+
+        self._kdata = self._get(self._url_path)
+
+        self._defaults = {}
+        self._data = {}
+
+        self.__doc__ = requests.get('{}/doc'.format(self._url_path)).text
+
+        for k, v in self._kdata.items():
+            # get defaults for this func
+            default_path = '{}/{}/defaults'.format(self._url_path, k)
+            self._defaults[k] = self._get(default_path)
+
+            # get cached data (result of calling with no args)
+            data_path = '{}/{}/data'.format(self._url_path, k)
+            self._data[k] = self._get(data_path)
+
+            doc_path = '{}/{}/doc'.format(self._url_path, k)
+            func_doc = requests.get(doc_path).text
+
+            # get kamodofied function
+            func = self.load_func(k)
+            func.__doc__ += '\n' + func_doc
+            self[k] = kamodofy(
+                func,
+                data=self._data[k],
+                units=v['units'],
+                )
+
+    def _get(self, url_path):
+        req_result = requests.get(url_path)
+        try:
+            result = req_result.json() # returns a dictionary maybe
+        except json.JSONDecodeError as m:
+            print('could not decode request {}'.format(req_result.text))
+            raise json.JSONDecodeError(m)
+
+        if isinstance(result, str):
+            result_dict = json.loads(result, object_hook=deserialize)
+        else:
+            result_dict = result
+        return result_dict
+
+    def _call_func(self, func_name, **kwargs):
+        """construct the url and call api with params"""
+        url_path = '{}/{}'.format(self._url_path, func_name)
+        if self.verbose:
+            print('querying {}'.format(url_path))
+        params = []
+        for k, v in kwargs.items():
+            params.append((k, json.dumps(v, default=serialize)))
+        result = requests.get(
+            url=url_path,
+            params=params).json() #returns a dictionary
+
+        if isinstance(result, str):
+            if self.verbose:
+                print('reloading json as str')
+            result = json.loads(result, object_hook=deserialize)
+        else:
+            result = deserialize(result)
+        return result
+
+    def load_func(self, func_name):
+        """loads a function signature"""
+        signature = []
+        for arg, arg_default in self._defaults[func_name].items():
+            signature.append(forge.arg(arg, default=arg_default))
+
+        @forge.sign(*signature)
+        def api_func(*args, **kwargs):
+            """API function"""
+            return self._call_func(func_name, **kwargs)
+
+        api_func.__name__ = func_name
+        api_func.__doc__ = "{}/{}".format(self._url_path, func_name)
+        return api_func
 
 def compose(**kamodos):
     """Kamposes multiple kamodo instances into one"""

--- a/test_kamodo.py
+++ b/test_kamodo.py
@@ -1,0 +1,777 @@
+"""
+Tests for kamodo.py
+
+"""
+
+import numpy as np
+from sympy import symbols, Symbol
+import pytest
+from sympy.core.function import UndefinedFunction
+import pandas as pd
+from kamodo.kamodo import Kamodo, get_unit, kamodofy, Eq
+import functools
+from sympy import lambdify, sympify
+from kamodo.kamodo import get_abbrev
+from kamodo.util import get_arg_units
+from kamodo.util import get_unit_quantity, convert_to
+from kamodo.kamodo import from_kamodo, compose
+from sympy import Function
+from kamodo.kamodo import KamodoAPI
+from kamodo.util import serialize, NumpyArrayEncoder
+
+import warnings
+
+
+def test_Kamodo_expr():
+    a, b, c, x, y, z = symbols('a b c x y z')
+    kamodo = Kamodo(a=x ** 2, verbose=True)
+    try:
+        assert kamodo.a(3) == 3 ** 2
+    except:
+        print(kamodo.symbol_registry)
+        raise
+
+
+def test_Kamodo_ambiguous_expr():
+    a, b, c, x, y, z = symbols('a b c x y z')
+    with pytest.raises(NameError):
+        kamodo = Kamodo()
+        kamodo['a(b,c)'] = x ** 2 + y ** 2
+    kamodo = Kamodo()
+    kamodo['a(x, y)'] = x ** 2 + y ** 2
+    assert kamodo.a(3, 4) == 3 ** 2 + 4 ** 2
+
+
+def test_Kamodo_callable():
+    kamodo = Kamodo(f=lambda x: x ** 2, verbose=False)
+    assert kamodo.f(3) == 9
+    kamodo = Kamodo(f=lambda x, y: x ** 2 + y ** 3)
+    assert kamodo.f(3, 4) == 3 ** 2 + 4 ** 3
+
+
+def test_Kamodo_callable_array():
+    kamodo = Kamodo(f=lambda x: x ** 2)
+    assert (kamodo.f(np.linspace(0, 1, 107)) == np.linspace(0, 1, 107) ** 2).all()
+
+
+def test_Kamodo_str():
+    kamodo = Kamodo('f(a,x,b) = a*x+b')
+    try:
+        assert kamodo.f(3, 4, 5) == 3 * 4 + 5
+    except:
+        print(kamodo.signatures)
+        print(list(kamodo.keys()))
+        raise
+
+
+def test_Kamodo_latex():
+    kamodo = Kamodo('$f(a,x,b) = a^x+b $')
+    assert kamodo.f(3, 4, 5) == 3 ** 4 + 5
+
+
+def test_Kamodo_get():
+    kamodo = Kamodo('$f(a,x,b) = a^x+b $')
+    try:
+        assert kamodo['f'](3, 4, 5) == 3 ** 4 + 5
+    except:
+        print(kamodo.signatures)
+        print(list(kamodo.keys()))
+        raise
+
+
+def test_Kamodo_set():
+    kamodo = Kamodo()
+    kamodo['f(a,x,b)'] = '$a^x+b$'
+    assert kamodo.f(2, 3, 4) == 2 ** 3 + 4
+
+
+def test_Kamodo_mismatched_symbols():
+    with pytest.raises(NameError):
+        kamodo = Kamodo('$f(a,b) = a + b + c$', verbose=False)
+        assert 'f' not in kamodo
+
+
+def test_Kamodo_assign_by_expression():
+    kamodo = Kamodo()
+    f, x, y = symbols('f x y')
+    kamodo['f(x, y)'] = x ** 2 + y ** 2
+    assert kamodo['f'](3, 4) == 3 ** 2 + 4 ** 2
+    assert kamodo.f(3, 4) == 3 ** 2 + 4 ** 2
+
+
+def test_Kamodo_assign_by_callable():
+    kamodo = Kamodo(f=lambda x: x ** 2, verbose=False)
+    assert kamodo['f'](3) == 3 ** 2
+    assert kamodo.f(3) == 3 ** 2
+    Kamodo(f=lambda x, y: x + y)
+
+    def rho(x, y):
+        return x + y
+
+    kamodo['g'] = rho
+    assert kamodo.g(3, 4) == 3 + 4
+
+
+def test_Kamodo_composition():
+    # f, g = symbols('f g', cls=UndefinedFunction)
+    # x = Symbol('x')
+    kamodo = Kamodo(f="$x^2$", verbose=True)
+    kamodo['g(x)'] = "$f(x) + x^2$"
+    kamodo['h(x)'] = 'g**2 + x**2'
+    
+    try:
+        assert kamodo.f(3) == 3 ** 2
+        assert kamodo.g(3) == 3 ** 2 + 3 ** 2
+        assert kamodo.h(3) == (3 ** 2 + 3 ** 2) ** 2 + 3 ** 2
+    except:
+        print(kamodo)
+        raise
+
+
+def test_Kamodo_reassignment():
+    a, b, c, x, y, z, r = symbols('a b c x y z r')
+    kamodo = Kamodo('f(x) = 3*x+5', verbose=True)
+    kamodo['r(x,y)'] = x + y
+    kamodo['r(x,y)'] = "3*x + y"
+    assert kamodo.r(1, 1) != 2
+    assert kamodo.r(1, 1) == 4
+
+def test_Kamodo_reassignment_units():
+    kamodo = Kamodo(verbose=True)
+    kamodo['s(x[km],y[km])[kg]'] = 'x + y'
+    assert kamodo.s(1, 1) == 2
+    kamodo['s(x[m],y[m])[g]'] = '3*x + y'
+    assert kamodo.s(1, 1) == 4
+
+
+def test_multivariate_composition():
+    kamodo = Kamodo(f='x**2', g=lambda y: y ** 3, verbose=True)
+    kamodo['h(x,y)'] = 'f(x) + g(y)'
+    kamodo['i(x,y)'] = 'x + f(h(x,y))'
+    assert kamodo.h(3, 4) == 3 ** 2 + 4 ** 3
+    assert kamodo.i(3, 4) == 3 + (3 ** 2 + 4 ** 3) ** 2
+
+
+def test_special_numbers():
+    kamodo = Kamodo()
+    kamodo['f'] = "${}^x$".format(np.e)
+    assert np.isclose(kamodo.f(1), np.e)
+
+
+def test_function_registry():
+    kamodo = Kamodo("f(x) = x**2", "g(y) = y**3")
+    kamodo['r(x,y)'] = "(x**2 + y**2)**(1/2)"
+    kamodo['h(x,y)'] = 'f + g + r'
+    assert 'h' in kamodo.signatures
+
+
+def test_symbol_key():
+    f = symbols('f', cls=UndefinedFunction)
+    x = Symbol('x')
+    f_ = f(x)
+    kamodo = Kamodo(verbose=True)
+    kamodo[f_] = x ** 2
+    assert kamodo.f(3) == 9
+
+
+def test_compact_variable_syntax():
+    f = symbols('f', cls=UndefinedFunction)
+    x = symbols('x')
+    kamodo = Kamodo(f='x**2')  # f also registers f(x)
+    kamodo['g(x)'] = 'f + x'
+    assert kamodo.g(3) == 3 ** 2 + 3
+
+
+def test_unit_registry():
+    def rho(x, y):
+        return x * y
+
+    def v(x, y):
+        return x + y
+
+    v.meta = dict(units='km/s')
+    kamodo = Kamodo(v=v, verbose=False)
+    kamodo['rho[kg/cc]'] = rho
+    try:
+        assert kamodo.rho.meta['units'] == 'kg/cc'
+        assert kamodo.v.meta['units'] == 'km/s'
+    except:
+        print('\n', pd.DataFrame(kamodo.signatures))
+        raise
+
+    with pytest.raises(NameError):
+        kamodo['p[kg]'] = v
+    assert 'p' not in kamodo
+
+
+def test_to_latex():
+    warnings.simplefilter('error')
+    kamodo = Kamodo(f='x**2', verbose=True)
+    assert str(kamodo.to_latex(mode='inline')) == r'$f{\left(x \right)} = x^{2}$'
+    kamodo = Kamodo(g='x', verbose=True)
+    assert str(kamodo.to_latex(mode='inline')) == r'$g{\left(x \right)} = x$'
+    kamodo['f(x[cm])[kg]'] = 'x**2'
+    kamodo['g'] = kamodofy(lambda x: x**2, units='kg', arg_units=dict(x='cm'), equation='$x^2$')
+    kamodo['h'] = kamodofy(lambda x: x**2, units='kg', arg_units=dict(x='cm'))
+    kamodo.to_latex()
+
+
+def test_expr_conversion():
+    kamodo = Kamodo('$a[km] = x$', verbose=True)
+    print(kamodo.items())
+    kamodo.a
+
+def test_get_unit_fail():
+    with pytest.raises(NameError):
+        get_unit('unregistered units$')
+    with pytest.raises(NameError):
+        get_unit('runregistered')
+
+def test_get_unit_quantity():
+    mykm = get_unit_quantity('mykm', 'km', scale_factor=2)
+    mygm = get_unit_quantity('mygm', 'gram', scale_factor=4)
+    assert str(convert_to(mykm, get_unit('m'))) == '2000*meter'
+    assert str(convert_to(mygm, get_unit('kg'))) == 'kilogram/250'
+
+# def test_validate_units():
+#     f, x = symbols('f x')
+#     with pytest.raises(ValueError):
+#         validate_units(Eq(f, x), dict(f=get_unit('kg'), x=get_unit('m')))
+#     validate_units(Eq(f, x), dict(f=get_unit('kg'), x=get_unit('g')))
+
+#     lhs_units = validate_units(sympify('f(x)'), dict(f=get_unit('kg'), x=get_unit('m')))
+#     print(lhs_units)
+
+
+def test_unit_conversion():
+    kamodo = Kamodo('$a(x[m])[km/s] = x$',
+                    '$b(y[cm])[m/s] = y$', verbose=True)
+    kamodo['c(x[m],y[m])[m/s]'] = '$a + b$'
+    assert kamodo.c(1, 2) == 1000 + 200
+
+
+def test_get_unit():
+    assert get_unit('kg/m^3') == get_unit('kg/m**3')
+
+
+def test_unit_conversion_syntax():
+    kamodo = Kamodo('rho[kg/m^3] = x', verbose=True)
+    with pytest.raises(NameError):
+        kamodo['d[kg]'] = 'rho'
+        print(kamodo.detail())
+
+
+def test_unit_composition():
+    kamodo = Kamodo('m[kg] = x', verbose=True)
+    kamodo['v[km/s]'] = 'y'
+    kamodo['p(x,y)'] = 'm*v'
+    try:
+        assert get_unit(kamodo.signatures['p']['units']) == get_unit('kg*km/s')
+    except:
+        print(kamodo.signatures)
+        raise
+
+
+def test_unit_function_composition():
+    kamodo = Kamodo('X[m] = x', verbose=True)
+
+    @kamodofy(units='km/s', arg_units=dict(x = 'm'))
+    def v(x):
+        return x
+
+    kamodo['v'] = v
+    kamodo['speed'] = 'v(X)'
+    assert kamodo.speed.meta['units'] == 'km/s'
+
+
+def test_method_args():
+    class TestModel(Kamodo):
+        def __init__(self, *args, **kwargs):
+            super(TestModel, self).__init__(*args, **kwargs)
+            self['rho'] = self.density
+
+        def density(self, alt, lat, lon):
+            return alt + lat + lon
+
+        density.meta = dict(units='1/cm^3')
+
+    test = TestModel(verbose=True)
+    assert str(list(test.keys())[0].args[0]) != 'self'
+
+    test['r(alt, lat, lon)[1/m^3]'] = 'rho'
+    try:  # check that args are in the correct order
+        assert list(test.signatures.values())[0]['symbol'].args == list(test.signatures.values())[1]['symbol'].args
+    except:
+        print('\n', test.detail())
+        raise
+
+
+def test_komodofy_decorator():
+    @kamodofy(units='kg/cm^3')
+    def my_density(x, y, z):
+        return x + y + z
+
+    assert my_density.meta['units'] == 'kg/cm^3'
+    assert my_density(3, 4, 5) == 12
+
+
+def test_komodofy_register():
+    @kamodofy(units='kg/cm^3')
+    def my_density(x, y, z):
+        return x + y + z
+
+    kamodo = Kamodo(rho=my_density)
+    assert kamodo.rho.meta['units'] == 'kg/cm^3'
+
+
+def test_komodofy_method():
+    class TestModel(Kamodo):
+        def __init__(self, *args, **kwargs):
+            super(TestModel, self).__init__(*args, **kwargs)
+            self['rho'] = self.density
+
+        @kamodofy(units='1/cm^3')
+        def density(self, alt, lat, lon):
+            return alt + lat + lon
+
+    test = TestModel(verbose=False)
+    assert test.density.meta['units'] == '1/cm^3'
+
+
+#   try:
+#       assert len(kamodo.detail()) == 1
+#   except:
+#       print kamodo.symbol_registry
+#       print kamodo.detail()
+#       raise
+
+# # def test_remove_symbol():
+# #     kamodo = Kamodo(f = 'x')
+# #     kamodo['g'] = '2*f'
+# #     kamodo.remove_symbol('f')
+# #     try:
+# #         assert len(kamodo.symbol_registry) == 1
+# #         assert len(kamodo) == 2
+# #     except:
+# #         print '\n',kamodo.detail()
+# #         raise
+
+# def test_function_arg_ordering():
+#   def x(r,theta,phi):
+#       '''converts from spherical to cartesian'''
+#       return r*np.sin(theta)*np.cos(phi)
+
+#   kamodo = Kamodo(x = x)
+#   rhs_args = get_function_args(kamodo.x)
+#   lhs_args = kamodo.signatures.values()[0]['symbol'].args
+
+#   for i in range(3):
+#       assert lhs_args[i] == rhs_args[i]
+
+# def test_function_change_of_variables():
+#   def rho(x):
+#       return x**2
+
+#   kamodo = Kamodo(x = 'y')
+#   kamodo['rho'] = rho
+#   kamodo['rho_perp'] = 'rho(x)'
+
+#   assert str(get_function_args(kamodo.rho_perp)[0]) == 'y'
+
+
+def test_kamodofy_update_attribute():
+    @kamodofy(units='cm', update='y')
+    def f(x):
+        return x # pragma: no cover
+
+    kamodo = Kamodo(f=f)
+    assert f.update == 'y'
+
+
+def test_kamodo_coupling():
+    @kamodofy(units='cm', update='y')
+    def y_iplus1(y, x):
+        return y + x
+
+    @kamodofy(units='m')
+    def x_iplus1(x, y):
+        return x - y
+
+    kamodo = Kamodo()
+    kamodo['x_iplus1'] = x_iplus1
+    kamodo['y_iplus1'] = y_iplus1
+
+    kamodo.x_iplus1.update = 'x'
+    assert kamodo.x_iplus1.update == 'x'
+    assert kamodo.y_iplus1.update == 'y'
+
+    simulation = kamodo.simulate(y=1, x=0, steps=1)
+
+    for state in simulation:
+        pass
+
+    assert state['x'] == -1
+    assert state['y'] == 0
+
+
+def test_units():
+    nT = get_unit('nT')
+    assert str(nT) == 'nanotesla'
+    assert str(nT.abbrev) == 'nT'
+
+    R_E = get_unit('R_E')
+    assert str(R_E) == 'earth radii'
+    assert str(R_E.abbrev) == 'R_E'
+
+
+def test_default_composition():
+    ## Need to wrap function defaults
+    def create_wrapped(args, expr):
+        func = lambdify(args, expr)
+
+        @functools.wraps(func)
+        def wrapped(*_args, **kwargs):
+            # Write the logic here to parse _args and kwargs for the arguments as you want them
+            return func(*actual_args)
+
+        return wrapped
+
+
+def test_vectorize():
+    @np.vectorize
+    @kamodofy(units='kg')
+    def f(x, y):
+        return x + y
+
+    kamodo = Kamodo(f=f)
+    kamodo.f([3, 4, 5], 5)
+    kamodo.evaluate('f', x=3,y=2)
+
+
+def test_redefine_variable():
+    kamodo = Kamodo(rho='x + y')
+    kamodo['rho'] = 'a + b'
+    kamodo['rho(a,b)'] = 'a*b'
+
+def test_unit_composition_registration():
+    server = Kamodo(**{'M': kamodofy(lambda r=3: r, units='kg'),
+                       'V[m^3]': (lambda r: r**3)}, verbose=True)
+    user = Kamodo(mass=server.M, vol=server.V,
+              **{'rho(r)[g/cm^3]':'mass/vol'}, verbose=True)
+
+    result = (3/3**3)*(1000)*(1/10**6)
+    assert np.isclose(user.rho(3), result)
+
+
+def test_unit_expression_registration():
+    kamodo = Kamodo(verbose=True)
+    kamodo['f(x[cm])[cm**2]'] = 'x**2'
+
+
+def test_multi_unit_composition():
+    kamodo = Kamodo('a(x[s])[km] = x', verbose=True)
+    kamodo['b(x[cm])[g]'] = 'x'
+    kamodo['c'] = 'b(a)'
+    print(kamodo.c.meta)
+    assert kamodo.c.meta['units'] == 'g'
+    assert kamodo.c.meta['arg_units']['x'] == str(get_abbrev(get_unit('s')))
+
+def test_unit_composition_conversion():
+    kamodo = Kamodo('a(x[kg])[m] = x', verbose=True)
+    kamodo['b(x[cm])[g]'] = 'x'
+    kamodo['c'] = 'b(a)'
+
+    assert kamodo.c.meta['units'] == 'g'
+    assert kamodo.c.meta['arg_units']['x'] == 'kg'
+    assert kamodo.c(3) == kamodo.b(100*kamodo.a(3))
+
+
+def test_get_arg_units():
+
+    def assign_unit(symbol, **units):
+        if isinstance(symbol, str):
+            symbol = sympify(symbol)
+        return symbol.subs(units)
+
+    f_units = assign_unit('f(x,y)', x=get_unit('s'), y=get_unit('hour'))
+    g_units = assign_unit('g(a,b,c)', a=get_unit('km'), b=get_unit('cm'), c=get_unit('m'))
+    unit_registry = {
+        sympify('f(x,y)'): f_units,
+        f_units: get_unit('kg/m^3'),
+        sympify('g(a,b,c)'): g_units,
+        g_units: get_unit('m^2')
+    }
+    x, c = symbols('x c')
+    result = get_arg_units(sympify('h(g(f(x,y)))'), unit_registry)
+    assert result[x] == get_unit('s')
+    result = get_arg_units(sympify('f(x,y)*g(a,b,c)'), unit_registry)
+    assert result[c] == get_unit('m')
+
+def test_compose_unit_multiply():
+    kamodo = Kamodo('a(x[kg])[m] = x', verbose=True)
+    kamodo['e'] = '2*a'
+
+
+def test_compose_unit_add():
+    kamodo = Kamodo(verbose=True)
+
+    @kamodofy(units='m', arg_units={'x': 'kg'})
+    def a(x):
+        return x
+
+    kamodo['a'] = a
+    kamodo['b(y[cm])[km]'] = 'y'
+    kamodo['c(x,y)[km]'] = '2*a + 3*b'
+    assert kamodo.c.meta['arg_units']['x'] == str(get_abbrev(get_unit('kg')))
+    assert kamodo.c.meta['arg_units']['y'] == str(get_abbrev(get_unit('cm')))
+    result = 2*(3)/1000 + 3*(3)
+    assert kamodo.c(3, 3) == result
+
+def test_compose_unit_raises():
+
+    with pytest.raises(NameError):
+        kamodo = Kamodo('a(x[kg])[m] = x',
+                        'b(y[cm])[km] = y', verbose=True)
+
+        # this should fail since x is registered with kg
+        kamodo['c(x[cm],y[cm])[km]'] = '2*a + 3*b'
+
+
+def test_repr_latex():
+    kamodo = Kamodo(f='x')
+    assert kamodo._repr_latex_() == r'\begin{equation}f{\left(x \right)} = x\end{equation}'
+    kamodo = Kamodo(f=lambda x:x)
+    assert kamodo.f._repr_latex_() == '$f{\\left(x \\right)} = \\lambda{\\left(x \\right)}$'
+
+
+def test_dataframe_detail():
+    kamodo = Kamodo(f='x')
+    type(kamodo.detail())
+    assert len(kamodo.detail()) == 1
+    assert isinstance(kamodo.detail(), pd.DataFrame)
+
+def test_from_kamodo():
+    kamodo = Kamodo(f='x')
+    knew = from_kamodo(kamodo, g='f**2')
+    assert knew.g(3) == 9
+
+
+def test_jit_evaluate():
+    """Just-in-time evaluation"""
+    kamodo = Kamodo(f='x')
+    assert kamodo.evaluate('g=f**2', x = 3)['x'] == 3
+    with pytest.raises(SyntaxError):
+        kamodo.evaluate('f**2', x = 3)['x'] == 3
+
+def test_eval_no_defaults():
+    kamodo = Kamodo(f='x', verbose=True)
+    kamodo['g'] = lambda x=3: x
+    kamodo['h'] = kamodofy(lambda x=[2,3,4]: (kamodofy(lambda x_=np.array([1]): x_**2) for x_ in x))
+    assert kamodo.evaluate('f', x=3)['x'] == 3
+    assert kamodo.evaluate('g')['x'] == 3
+    assert kamodo.evaluate('h')['x_'][-2] == 1.
+
+def test_compose():
+    k1 = Kamodo(f='x')
+    k2 = Kamodo(g='y**2', h = kamodofy(lambda x: x**3))
+    k3 = compose(m1=k1, m2=k2)
+    assert k3.f_m1(3) == 3
+    assert k3.g_m2(3) == 3**2
+    assert k3.h_m2(3) == 3**3
+    k3['h(f_m1)'] = 'f_m1'
+    assert k3.h(3) == 3
+
+def test_symbol_replace():
+    k = Kamodo(f='x', verbose=True)
+
+    f1, f2 = list(k.keys())
+    print('\n|||||',f1, f2, '||||||')
+    k[f1] = 'x**2'
+    assert k.f(3) == 9
+    print('\n|||||', *list(k.keys()), '|||||')
+    k[f2] = 'x**3'
+    print('\n|||||', *list(k.keys()), '|||||')
+    assert k.f(3) == 27
+
+def test_contains():
+    kamodo = Kamodo(f='x', verbose=True)
+    assert 'f' in kamodo
+    assert 'f( x )' in kamodo
+    f, x = symbols('f x')
+    assert f in kamodo # f is a symbo
+    f = Function(f) # f is an Unefined Function
+    assert f in kamodo
+    assert f(x) in kamodo
+    assert f('x') in kamodo
+
+def test_unusual_signature():
+    with pytest.raises(NotImplementedError):
+        kamodo = Kamodo()
+        kamodo['f(x)=f(cm)=kg'] = 'x'
+    with pytest.raises(NotImplementedError):
+        kamodo = Kamodo('f(x)=f(cm)=kg=x')
+
+
+# def test_remove_symbol():
+#     kamodo = Kamodo(f='x', verbose=True)
+#     kamodo.remove_symbol('f')
+#     assert 'f' not in kamodo
+
+def test_method_registry():
+    
+    class MyClass(Kamodo):
+        @kamodofy
+        def f(self, x):
+            return x**2
+
+    myclass = MyClass()
+    myclass['f'] = myclass.f
+
+def test_del_function():
+    kamodo = Kamodo(f='x', g='y', h='y', verbose=True)
+    del(kamodo.f)
+    assert 'f' not in kamodo
+    assert 'f' not in kamodo.signatures
+    del(kamodo['g'])
+    assert 'g' not in kamodo
+    del(kamodo['h(y)'])
+    print(kamodo.keys())
+    assert 'h(y)' not in kamodo
+
+    with pytest.raises(AttributeError):
+        del(kamodo.y)
+
+def test_simple_figure():
+    @kamodofy(units='kg', hidden_args=['ions'])
+    def f_N(x_N):
+        return x_N**2
+
+    kamodo = Kamodo(f_N=f_N,verbose=True)
+    kamodo.plot(f_N=dict(x_N=np.linspace(-4, 3, 30)))
+
+def test_unavailable_4d_plot_type():
+    def g(x=np.array([1]),
+          y=np.array([1]),
+          z=np.array([1]),
+          t=np.array([1])):
+        return x**2 + y**2 + z**2 + t**2
+
+    kamodo = Kamodo(g=g, verbose=True)
+    with pytest.raises(KeyError):
+        kamodo.plot('g')
+
+def test_multiple_traces():
+    kamodo = Kamodo(f='x', g='x**2')
+    kamodo.plot(
+        f=dict(x=np.linspace(-1, 1, 10)),
+        g=dict(x=np.linspace(-5, 5, 10)))
+
+def test_unitless_composition():
+    @kamodofy
+    def alpha(x):
+        return x
+
+    @kamodofy
+    def beta(y):
+        return y
+
+
+    kamodo = Kamodo(alpha=alpha, beta_=beta, verbose=True)
+    kamodo['Gamma'] = 'alpha(beta_)'
+    kamodo
+
+def test_reserved_name():
+    kamodo = Kamodo(verbose=True)
+  
+    @kamodofy
+    def test(x, y):
+        return x+y
+    with pytest.raises(NotImplementedError):
+        kamodo['test'] = test
+
+
+class Ktest(Kamodo):
+    def __init__(self, **kwargs):
+        super(Ktest, self).__init__()
+
+        t_N = pd.date_range('Nov 9, 2018', 'Nov 20, 2018', freq = 'H')
+        @kamodofy(units='kg/m^3')
+        def rho_N(t_N=t_N):
+            t_N = pd.DatetimeIndex(t_N)
+            t_0 = pd.to_datetime('Nov 9, 2018') 
+            try:
+                dt_days = (t_N - t_0).total_seconds()/(24*3600)
+            except TypeError as err_msg:
+                return 'cannot work with {} {}  {}'.format(type(t_N), type(t_N[0]), err_msg)
+
+            result = np.abs(weierstrass(dt_days))
+            return result
+
+        @kamodofy(units='nPa')
+        def p(x=np.linspace(-5, 5, 30)):
+            try:
+                return x**2
+            except TypeError as m:
+                print(m)
+                print(type(x), x[0])
+                raise
+
+        @kamodofy(
+            equation="\sum_{n=0}^{500} (1/2)^n cos(3^n \pi x)",
+            citation='https://en.wikipedia.org/wiki/Weierstrass_function'
+            )
+        def weierstrass(x = np.linspace(-2, 2, 1000)):
+            '''
+            Weierstrass  function
+            A continuous non-differentiable 
+            https://en.wikipedia.org/wiki/Weierstrass_function
+            '''
+            nmax = 500
+            n = np.arange(nmax)
+
+            xx, nn = np.meshgrid(x, n)
+            ww = (.5)**nn * np.cos(3**nn*np.pi*xx)
+            return ww.sum(axis=0)
+                
+
+        self['rho_N'] = rho_N
+        self['p'] = p
+        self['Weierstrass'] = weierstrass
+
+
+def test_kamodo_inline_merge():
+    k1 = Kamodo(f='x**2')
+    k2 = Kamodo(g=lambda y: y-1)
+
+    # create a local namespace holding both kamodo objects
+    ns = {'k1':k1, 'k2': k2}
+    k3 = Kamodo(myf = sympify('k1.f(x) + k2.g(y)', locals=ns))
+    assert k3.myf(x=3, y=4) == 3**2 + 4 - 1
+
+def test_default_forwarding():
+    x = np.linspace(-5, 5, 12)
+    
+    def f(x=x):
+        return x**2
+    
+    k = Kamodo(f=f)
+    k['g'] = 'f+2'
+    assert len(k.g()) == 12
+    
+#this will break without new decompose_unit function
+#it will be false until sympy_units.N is no longer overruled elsewhere
+def test_units_N():
+    unit_out = str(get_unit('N'))
+    assert unit_out == 'newton'
+  
+#this will break without new decompose_unit function
+#it will be false until sympy_units.S is no longer overruled elsewhere
+def test_units_S():
+    unit_out = str(get_unit('S'))
+    assert unit_out == 'siemen'
+        
+#this will break without new string replace line ('rad' -> 'radian')
+def test_units_rad():
+    unit_out = str(get_unit('rad'))
+    assert unit_out == 'radian'        
+


### PR DESCRIPTION
1. Removed (C) from file and changed .util to util to prevent errors calling kamodo from C++.
2. Changed call structure to reflect directory structure. This caused errors when calling from C++.
3. Added decompose_unit function to handle units that sympy doesn't accept. This helps kamodo accept functions with arg_units or return units, but breaks later in to_latex representation of the function.
4. Added tests in test_kamodo.py related to this (bottom of file). Not sure how to test for proper latex representation, though.
5. Replaced getfullargspec(func).args line in get_function_args b/c was returning an empty argument list for wrapped functions with dimensionless input and output units. Replaced related import statement with updated one. Now works with plasmapy wrapper.
6. Removed nT and nPa definitions in util.py because it is included in the prefix code directly below the definitions. The same units still work and are represented correctly.
7. Added a note about the N and S puzzle in util.py

Note: sympy_units has newtons and siemens (sympy_units.N and sympy_units.S), but won't recognize the units through kamodo. Asher mentioned something about putting them through a symbol call later that may be messing this up? The new decompose_unit feature gets around this for now, but the units in the kamodofy call have to be corrected. A similar approach works in the kamodofyplasmapy wrapper without any error in the latex representation of the corresponding kamodo object, but the correction occurs in the units and arg_units definitions in the kamodofy call itself, not after the units and arg_units are defined.