### PR TITLE
Fix nonexistent variable error

### DIFF
--- a/kamodo_ccmc/flythrough/SF_utilities.py
+++ b/kamodo_ccmc/flythrough/SF_utilities.py
@@ -172,7 +172,9 @@ def save_times(file_patterns, sat_time, model, verbose=False):
     #print errors for any remaining 'bad' times
     nbad_times = len(sat_time)-l_idx
     #print('save_times function', len(sat_time), l_idx)
-    if nbad_times>0:
+    if nbad_times==1:
+        print(f'{nbad_times} time is not in model output files and is excluded from the flythrough.')
+    elif nbad_times>0:
         print(f'{nbad_times} times are not in model output files and are excluded from the flythrough.')
         
     return sat_time, times, net_idx

--- a/kamodo_ccmc/flythrough/SatelliteFlythrough.py
+++ b/kamodo_ccmc/flythrough/SatelliteFlythrough.py
@@ -279,7 +279,7 @@ def ModelFlythrough(model, file_dir, variable_list, sat_time, c1, c2, c3,
         #correct input filename and split into useful pieces
         plot_file_prefix = basename(plot_output)
         plot_file_dir = plot_output.split(plot_file_prefix)[0]
-        if model not in file_prefix:
+        if model not in plot_file_prefix:
             plot_file_dir+=model+'_'     
         plot_file_prefix+='_'            
         


### PR DESCRIPTION
The recent [PR #71](https://github.com/nasa/Kamodo/pull/71) broke the flythrough code because the variable `file_prefix` was renamed to `plot_file_prefix` everywhere except line 282. This resulted in `NameError: name 'file_prefix' is not defined` when that line was reached. 

This PR fixes that bug.

I also took the opportunity to improve the grammar of an error message when only one time is not in the model output files.