### PR TITLE
requirements.txt added. packages can be installed as: pip install -r requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+numpy
+scipy
+sympy
+pandas
+plotly==5.11.0
+pytest
+psutil
+kamodo
+spacepy
+astropy
+hapiclient


### PR DESCRIPTION
requirements.txt added into Kamodo root folder. 
It includes plotly==5.11.0, which adresses #99  