### PR TITLE
Update interpolate_amrdata_extension_build.py

### DIFF
--- a/kamodo_ccmc/readers/OCTREE_BLOCK_GRID/interpolate_amrdata_extension_build.py
+++ b/kamodo_ccmc/readers/OCTREE_BLOCK_GRID/interpolate_amrdata_extension_build.py
@@ -37,7 +37,7 @@ int trace_fieldline_octree(float x_start,float y_start,float z_start, float r_en
 
 
 # on Windows (os.name == 'nt'), no explicit list of libraries is needed
-libraries=['']    
+libraries=[]    
 # link with the math library (libm) in Unix-style OS (Linux, Mac-OS)
 if os.name == 'posix':
     libraries=['m']


### PR DESCRIPTION
The initial value of the libraries variable (line 40) should be an empty list, not a list with an empty string.