### PR TITLE
Enabling interpolation through data in s3 buckets

### DIFF
--- a/kamodo_ccmc/flythrough/SF_output.py
+++ b/kamodo_ccmc/flythrough/SF_output.py
@@ -8,6 +8,7 @@ import numpy as np
 from kamodo import Kamodo, kamodofy
 from scipy.interpolate import interp1d
 from datetime import datetime, timezone
+from kamodo_ccmc.readers.reader_utilities import _open
 
 
 @np.vectorize
@@ -93,7 +94,7 @@ def Functionalize_SFResults(model, results, kamodo_object=None):
 def SFcdf_reader(filename):
     '''Loads the data from a cdf file that was written by the SFdata_tocdf
     routine below into a nested dictionary.'''
-    from netCDF4 import Dataset
+    from kamodo_ccmc.readers.reader_utilities import Dataset
 
     cdf_data = Dataset(filename, 'r')
     cdf_dict = {key: {'units': cdf_data.variables[key].units,
@@ -111,10 +112,10 @@ def SFdata_tocdf(filename, model_filename, model_name, results_dict,
                  results_units, coord_type, coord_grid):
     '''Write satellite flythrough time series data to a netCDF4 file.'''
 
-    from netCDF4 import Dataset
+    from netCDF4 import Dataset as Dataset4
 
     # start new output object
-    data_out = Dataset(filename, 'w', format='NETCDF4')
+    data_out = Dataset4(filename, 'w', format='NETCDF4')
     print(model_filename)
     data_out.modelfile = model_filename
     data_out.model = model_name
@@ -146,7 +147,7 @@ def SFcsv_reader(filename, delimiter=','):
 
     # open file
     from csv import reader
-    read_obj = open(filename, 'r')
+    read_obj = _open(filename, 'r')
     csv_reader = reader(read_obj, delimiter=delimiter)
 
     # sort out header
@@ -201,7 +202,7 @@ def SFdata_tocsv(filename, model_filename, model_name, results_dict,
             time_key = key
             break
 
-    data_out = open(filename, 'w')
+    data_out = open(filename, 'w')  # not using s3 capable version
     if not isinstance(model_filename, list):
         data_out.write(f'#Model files used:, {model_filename}')
     else:
@@ -236,7 +237,7 @@ def SFdata_toascii(filename, model_filename, model_name, results_dict,
             time_key = key
             break
 
-    data_out = open(filename, 'w')
+    data_out = open(filename, 'w')  # not using s3 capable version
     if not isinstance(model_filename, list):
         data_out.write(f'#Model files used:\t {model_filename}')
     else:

--- a/kamodo_ccmc/flythrough/SF_utilities.py
+++ b/kamodo_ccmc/flythrough/SF_utilities.py
@@ -198,15 +198,10 @@ def File_UTCTimes(model, file_dir):
     preprocessed files if needed.'''
 
     # get times dictionary and datetime filedate object from files
-    list_file = file_dir + model +'_list.txt'
-    time_file = file_dir + model +'_times.txt'
-    if isfile(list_file):
-        times, tmp, filedate, tmp = read_timelist(time_file, list_file)
-    else:
-        reader = MW.Model_Reader(model)
-        ko = reader(file_dir, filetime=True)  # creates any preprocessed files
-        times, filedate = ko.times, ko.filedate
-        del ko
+    reader = MW.Model_Reader(model)
+    ko = reader(file_dir, filetime=True)  # creates any preprocessed files
+    times, filedate = ko.times, ko.filedate
+    del ko
         
     # calculate minimum start time
     start, end = [], []

--- a/kamodo_ccmc/readers/amgeo_4D.py
+++ b/kamodo_ccmc/readers/amgeo_4D.py
@@ -78,9 +78,7 @@ attrs_var = ['imf_By', 'imf_Bz', 'solar_wind_speed']
 
 def MODEL():
     from kamodo import Kamodo
-    from glob import glob
-    import h5py
-    from os.path import isfile
+    import h5netcdf as h5py
     from numpy import array, NaN, unique, append, zeros, diff, sin, cos, insert
     from numpy import flip, concatenate, mean, broadcast_to, ones
     from numpy import transpose
@@ -150,9 +148,9 @@ def MODEL():
             list_file = file_dir + self.modelname + '_list.txt'
             time_file = file_dir + self.modelname + '_times.txt'
             self.times, self.pattern_files = {}, {}
-            if not isfile(list_file) or not isfile(time_file):
+            if not RU._isfile(list_file) or not RU._isfile(time_file):
                 # collect filenames
-                files = sorted(glob(file_dir+'*.h5'))
+                files = sorted(RU.glob(file_dir+'*.h5'))
                 patterns = unique([f[-4] for f in files])  # N or S
                 self.filename = ''.join([f+',' for f in files])[:-1]
                 self.filedate = datetime.strptime(
@@ -161,13 +159,14 @@ def MODEL():
                 # establish time attributes
                 for p in patterns:
                     # get list of files to loop through later
-                    pattern_files = sorted(glob(file_dir+'*'+p+'.h5'))
+                    pattern_files = sorted(RU.glob(file_dir+'*'+p+'.h5'))
                     self.pattern_files[p] = pattern_files
                     self.times[p] = {'start': [], 'end': [], 'all': []}
 
                     # loop through to get times
                     for f in range(len(pattern_files)):
-                        h5_data = h5py.File(pattern_files[f])
+                        h5_data = h5py.File(pattern_files[f],
+                                            phony_dims='access')
                         tmp_var = [key[:-1] for key in h5_data.keys() if key
                                    not in ['lats', 'lons']]
                         h5_data.close()
@@ -204,7 +203,8 @@ def MODEL():
 
             # collect variable list (in attributes of datasets)
             patterns = list(self.pattern_files.keys())
-            h5_data = h5py.File(self.pattern_files[patterns[0]][0])
+            h5_data = h5py.File(self.pattern_files[patterns[0]][0],
+                                phony_dims='access')
             key_list = list(h5_data[list(h5_data.keys())[0]].attrs.keys())
             key_list.extend(list(h5_data[list(h5_data.keys())[0]].keys()))
             h5_data.close()
@@ -245,13 +245,15 @@ def MODEL():
             # collect and arrange lat grid to be increasing (from neg to pos)
             # add buffer rows for NaN over equator region
             if 'N' in patterns:
-                h5_data = h5py.File(self.pattern_files['N'][0])
+                h5_data = h5py.File(self.pattern_files['N'][0],
+                                    phony_dims='access')
                 lat_N = unique(h5_data['lats'])  # 24 values
                 ldiff = diff(lat_N).min()
                 lat_N = array([lat_N[0]-ldiff, lat_N[0]-ldiff/10.] +
                               list(lat_N) + [90.])
                 if 'S' in patterns:
-                    h5_dataS = h5py.File(self.pattern_files['S'][0])
+                    h5_dataS = h5py.File(self.pattern_files['S'][0],
+                                        phony_dims='access')
                     # reverse order and make negative
                     lat_S = flip(unique(h5_dataS['lats']))*(-1)
                     lat_S = array([-90.] + list(lat_S) + [lat_S[-1]+ldiff/10.,
@@ -262,7 +264,8 @@ def MODEL():
                 else:
                     self._lat = lat_N  # append north pole value
             elif 'S' in patterns:  # N hemisphere file DNE
-                h5_data = h5py.File(self.pattern_files['S'][0])
+                h5_data = h5py.File(self.pattern_files['S'][0],
+                                    phony_dims='access')
                 # reverse order and make negative
                 lat_S = flip(unique(h5_data['lats']))*(-1)
                 ldiff = diff(lat_N).min()
@@ -392,7 +395,7 @@ def MODEL():
                 if gvar in attrs_var:
                     data = []
                     for f in self.pattern_files[ps[0]]:  # N, or S if N DNE
-                        h5_data = h5py.File(f)
+                        h5_data = h5py.File(f, phony_dims='access')
                         data.extend([h5_data[tkey].attrs[gvar] for tkey in
                                      h5_data.keys() if tkey not in
                                      ['lats', 'lons']])  # one float per time
@@ -400,7 +403,7 @@ def MODEL():
                 elif gvar[:-2] == 'int_joule_heat' and gvar[-1].upper() in ps:
                     data, p = [], gvar[-1].upper()
                     for f in self.pattern_files[p]:  # N, or S if N DNE
-                        h5_data = h5py.File(f)
+                        h5_data = h5py.File(f, phony_dims='access')
                         data.extend([h5_data[tkey][gvar[:-2]][0] for tkey in
                                      h5_data.keys() if tkey not in
                                      ['lats', 'lons']])  # one float per time
@@ -416,7 +419,8 @@ def MODEL():
             def func(i):  # i is the file number
                 # get first hemisphere data
                 if 'N' in ps:  # first one is N hemisphere
-                    h5_data = h5py.File(self.pattern_files['N'][i])
+                    h5_data = h5py.File(self.pattern_files['N'][i],
+                                        phony_dims='access')
                     tkeys = [key for key in h5_data.keys() if key not in
                              ['lats', 'lons']]
                     tmp = array([array(h5_data[tkey][gvar]) for tkey in
@@ -432,7 +436,8 @@ def MODEL():
                         data *= -1
                     # add S hemisphere data
                     if len(ps) == 2:
-                        h5_data = h5py.File(self.pattern_files['S'][i])
+                        h5_data = h5py.File(self.pattern_files['S'][i],
+                                            phony_dims='access')
                         tmp = array([array(h5_data[tkey][gvar]) for tkey in
                                      h5_data.keys() if tkey not in
                                      ['lats', 'lons']],
@@ -446,7 +451,8 @@ def MODEL():
                                             NaN_row, axis=2)
                         data = concatenate((south_data, data), axis=2)
                 elif 'S' in ps:  # only S hemisphere data
-                    h5_data = h5py.File(self.pattern_files['S'][i])
+                    h5_data = h5py.File(self.pattern_files['S'][i],
+                                        phony_dims='access')
                     tkeys = [key for key in h5_data.keys() if key not in
                              ['lats', 'lons']]
                     tmp = array([array(h5_data[tkey][gvar]) for tkey in
@@ -462,7 +468,8 @@ def MODEL():
                 # add one time step from the next file if not the last file
                 if i != len(self.pattern_files[ps[0]])-1:
                     if 'N' in ps:  # N hemisphere data is first
-                        h5_data = h5py.File(self.pattern_files['N'][i+1])
+                        h5_data = h5py.File(self.pattern_files['N'][i+1],
+                                            phony_dims='access')
                         time_list = list(h5_data.keys())[:-2]
                         tmp = array(h5_data[time_list[-1]][gvar], dtype=float,
                                     order='F')
@@ -477,7 +484,8 @@ def MODEL():
                             data1 *= -1
                         # add S hemisphere data
                         if len(ps) == 2:
-                            h5_data = h5py.File(self.pattern_files[ps[1]][i+1])
+                            h5_data = h5py.File(self.pattern_files[ps[1]][i+1],
+                                                phony_dims='access')
                             time_list = list(h5_data.keys())[:-2]
                             tmp = array(h5_data[time_list[-1]][gvar],
                                         dtype=float, order='F')
@@ -491,7 +499,8 @@ def MODEL():
                                 axis=1)
                             data1 = concatenate((south_data1, data1), axis=1)
                     elif 'S' in ps:  # only S hemisphere data
-                        h5_data = h5py.File(self.pattern_files['S'][i])
+                        h5_data = h5py.File(self.pattern_files['S'][i],
+                                            phony_dims='access')
                         tmp = array(h5_data[time_list[-1]][gvar], dtype=float,
                                     order='F')
                         h5_data.close()

--- a/kamodo_ccmc/readers/ctipe_4D.py
+++ b/kamodo_ccmc/readers/ctipe_4D.py
@@ -270,8 +270,7 @@ model_varnames = {'density': ['rho_ilev1', 'total mass density', 0, 'GDZ',
 def MODEL():
     from numpy import array, NaN, unique, append, where, transpose
     from time import perf_counter
-    from glob import glob
-    from os.path import basename, isfile
+    from os.path import basename
     from datetime import datetime, timezone
     from kamodo import Kamodo
     from netCDF4 import Dataset
@@ -350,9 +349,9 @@ def MODEL():
             list_file = file_dir + self.modelname + '_list.txt'
             time_file = file_dir + self.modelname + '_times.txt'
             self.times, self.pattern_files = {}, {}
-            if not isfile(list_file) or not isfile(time_file):
+            if not RU._isfile(list_file) or not RU._isfile(time_file):
                 # collect filenames
-                all_files = sorted(glob(file_dir+'*-plot-*.nc'))
+                all_files = sorted(RU.glob(file_dir+'*-plot-*.nc'))
                 files = [f for f in all_files if 'plasma' not in f]
                 patterns = unique([basename(f)[16:-3] for f in files])
                 # e.g. 'density', 'neutral', 'height'
@@ -367,7 +366,7 @@ def MODEL():
                 # establish time attributes, using 3D time as default
                 for p in patterns:
                     # get list of files to loop through later
-                    pattern_files = sorted(glob(file_dir+'*'+p+'*.nc'))
+                    pattern_files = sorted(RU.glob(file_dir+'*'+p+'*.nc'))
                     self.pattern_files[p] = pattern_files
                     self.times[p] = {'start': [], 'end': [], 'all': []}
 
@@ -562,7 +561,7 @@ def MODEL():
                 if p == 'density':
                     setattr(self, '_ilev1',
                             array(cdf_data.variables['plev']))
-                    if isfile(file_dir+'CTIPe_km.nc'):  # km_ilev1 from file
+                    if RU._isfile(file_dir+'CTIPe_km.nc'):  # km_ilev1 from file
                         km_data = Dataset(file_dir+'CTIPe_km.nc')
                         setattr(self, '_km_ilev1',
                                 array(km_data.variables['km_ilev1']))
@@ -572,7 +571,7 @@ def MODEL():
                 elif p == 'neutral':
                     setattr(self, '_ilev',
                             array(cdf_data.variables['plev']))
-                    if isfile(file_dir+'CTIPe_km.nc'):  # km_ilev from file
+                    if RU._isfile(file_dir+'CTIPe_km.nc'):  # km_ilev from file
                         km_data = Dataset(file_dir+'CTIPe_km.nc')
                         setattr(self, '_km_ilev',
                                 array(km_data.variables['km_ilev']))

--- a/kamodo_ccmc/readers/ctipe_4D.py
+++ b/kamodo_ccmc/readers/ctipe_4D.py
@@ -273,7 +273,6 @@ def MODEL():
     from os.path import basename
     from datetime import datetime, timezone
     from kamodo import Kamodo
-    from netCDF4 import Dataset
     import kamodo_ccmc.readers.reader_utilities as RU
 
     # main class
@@ -372,7 +371,8 @@ def MODEL():
 
                     # loop through to get times
                     for f in range(len(pattern_files)):
-                        cdf_data = Dataset(pattern_files[f])
+                        cdf_data = RU.Dataset(pattern_files[f],
+                                              filetype='netCDF3')
                         tmp = array(cdf_data.variables['time'])  # utc tstamps
                         self.times[p]['start'].append(tmp[0])
                         self.times[p]['end'].append(tmp[-1])
@@ -449,7 +449,8 @@ def MODEL():
             self.err_list, self.var_dict = [], {}
             for p in self.pattern_files.keys():
                 # check var_list for variables not possible in this file set
-                cdf_data = Dataset(self.pattern_files[p][0], 'r')
+                cdf_data = RU.Dataset(self.pattern_files[p][0],
+                                      filetype='netCDF3')
                 if len(variables_requested) > 0 and\
                         variables_requested != 'all':
                     gvar_list = [key for key, value in model_varnames.items()
@@ -549,7 +550,8 @@ def MODEL():
             # get coordinates from first file of each type
             self.variables = {}
             for p in self.pattern_files.keys():
-                cdf_data = Dataset(self.pattern_files[p][0], 'r')
+                cdf_data = RU.Dataset(self.pattern_files[p][0],
+                                      filetype='netCDF3')
                 lon = array(cdf_data.variables['lon'])
                 lon_le180 = list(where(lon <= 180)[0])  # 0 to 180
                 lon_ge180 = list(where(lon >= 180)[0])
@@ -562,7 +564,8 @@ def MODEL():
                     setattr(self, '_ilev1',
                             array(cdf_data.variables['plev']))
                     if RU._isfile(file_dir+'CTIPe_km.nc'):  # km_ilev1 from file
-                        km_data = Dataset(file_dir+'CTIPe_km.nc')
+                        km_data = RU.Dataset(file_dir+'CTIPe_km.nc',
+                                             filetype='netCDF3')
                         setattr(self, '_km_ilev1',
                                 array(km_data.variables['km_ilev1']))
                         setattr(self, '_km_ilev1_max', km_data.km_ilev1_max)
@@ -572,7 +575,8 @@ def MODEL():
                     setattr(self, '_ilev',
                             array(cdf_data.variables['plev']))
                     if RU._isfile(file_dir+'CTIPe_km.nc'):  # km_ilev from file
-                        km_data = Dataset(file_dir+'CTIPe_km.nc')
+                        km_data = RU.Dataset(file_dir+'CTIPe_km.nc',
+                                             filetype='netCDF3')
                         setattr(self, '_km_ilev',
                                 array(km_data.variables['km_ilev']))
                         setattr(self, '_km_ilev_max', km_data.km_ilev_max)
@@ -694,7 +698,7 @@ def MODEL():
                 '''
                 # get data from file
                 file = self.pattern_files[key][i]
-                cdf_data = Dataset(file)
+                cdf_data = RU.Dataset(file, filetype='netCDF3')
                 data = array(cdf_data.variables[gvar])
                 if hasattr(cdf_data.variables[gvar][0], 'fill_value'):
                     fill_value = cdf_data.variables[gvar][0].fill_value
@@ -704,7 +708,7 @@ def MODEL():
                 # if not the last file, tack on first time from next file
                 if file != self.pattern_files[key][-1]:  # interp btwn files
                     next_file = self.pattern_files[key][i+1]
-                    cdf_data = Dataset(next_file)
+                    cdf_data = RU.Dataset(next_file, filetype='netCDF3')
                     data_slice = array(cdf_data.variables[gvar][0])
                     cdf_data.close()
                     data = append(data, [data_slice], axis=0)

--- a/kamodo_ccmc/readers/dtm_4D.py
+++ b/kamodo_ccmc/readers/dtm_4D.py
@@ -30,8 +30,7 @@ model_varnames = {'Temp_exo': ['T_exo', 'Exospheric temperature', 0, 'GDZ',
 
 def MODEL():
     from time import perf_counter
-    from glob import glob
-    from os.path import basename, isfile
+    from os.path import basename
     from numpy import array, unique, NaN, append, transpose, where
     from datetime import datetime, timezone
     from netCDF4 import Dataset
@@ -97,10 +96,10 @@ def MODEL():
             list_file = file_dir + self.modelname + '_list.txt'
             time_file = file_dir + self.modelname + '_times.txt'
             self.times, self.pattern_files = {}, {}
-            if not isfile(list_file) or not isfile(time_file):
+            if not RU._isfile(list_file) or not RU._isfile(time_file):
                 t0 = perf_counter()  # begin timer
                 # figure out types of files present (2DTEC, 3DALL, 3DLST, etc)
-                files = sorted(glob(file_dir+'*.nc'))
+                files = sorted(RU.glob(file_dir+'*.nc'))
                 patterns = sorted(unique([basename(f)[:-11] for f in
                                           files]))  # cut off date
                 self.filename = ''.join([f+',' for f in files])[:-1]
@@ -111,7 +110,7 @@ def MODEL():
                 # establish time attributes
                 for p in patterns:  # only one pattern
                     # get list of files to loop through later
-                    pattern_files = sorted(glob(file_dir+p+'*.nc'))
+                    pattern_files = sorted(RU.glob(file_dir+p+'*.nc'))
                     self.pattern_files[p] = pattern_files
                     self.times[p] = {'start': [], 'end': [], 'all': []}
 

--- a/kamodo_ccmc/readers/dtm_4D.py
+++ b/kamodo_ccmc/readers/dtm_4D.py
@@ -33,7 +33,6 @@ def MODEL():
     from os.path import basename
     from numpy import array, unique, NaN, append, transpose, where
     from datetime import datetime, timezone
-    from netCDF4 import Dataset
     from kamodo import Kamodo
     import kamodo_ccmc.readers.reader_utilities as RU
 
@@ -116,7 +115,8 @@ def MODEL():
 
                     # loop through to get times, one day per file
                     for f in range(len(pattern_files)):
-                        cdf_data = Dataset(pattern_files[f])
+                        cdf_data = RU.Dataset(pattern_files[f],
+                                              filetype='netCDF3')
                         # minutes since 12am EACH file -> hrs since 12am 1st f
                         tmp = array(cdf_data.variables['time'])/60. + f*24.
                         self.times[p]['start'].append(tmp[0])
@@ -159,7 +159,7 @@ def MODEL():
             # there is only one pattern for DTM, so just save the one grid
             p = list(self.pattern_files.keys())[0]
             pattern_files = self.pattern_files[p]
-            cdf_data = Dataset(pattern_files[0], 'r')
+            cdf_data = RU.Dataset(pattern_files[0], filetype='netCDF3')
 
             # check var_list for variables not possible in this file set
             if len(variables_requested) > 0 and\
@@ -257,7 +257,7 @@ def MODEL():
                 '''
                 # get data from file
                 file = self.pattern_files[key][i]
-                cdf_data = Dataset(file)
+                cdf_data = RU.Dataset(file, filetype='netCDF3')
                 data = array(cdf_data.variables[gvar])
                 if hasattr(cdf_data.variables[gvar][0], 'fill_value'):
                     fill_value = cdf_data.variables[gvar][0].fill_value
@@ -267,7 +267,7 @@ def MODEL():
                 # if not the last file, tack on first time from next file
                 if file != self.pattern_files[key][-1]:  # interp btwn files
                     next_file = self.pattern_files[key][i+1]
-                    cdf_data = Dataset(next_file)
+                    cdf_data = RU.Dataset(next_file, filetype='netCDF3')
                     data_slice = array(cdf_data.variables[gvar][0])
                     cdf_data.close()
                     data = append(data, [data_slice], axis=0)

--- a/kamodo_ccmc/readers/gameragm_4D.py
+++ b/kamodo_ccmc/readers/gameragm_4D.py
@@ -51,10 +51,7 @@ def timestr_timestamp(time_str):
 
 def MODEL():
     from kamodo import Kamodo
-    from glob import glob
-    import h5py
-    from netCDF4 import Dataset
-    from os.path import isfile, basename
+    from os.path import basename
     from astropy.time import Time
     from datetime import datetime, timezone
     from numpy import array, NaN, ndarray, zeros, linspace, repeat
@@ -127,9 +124,9 @@ def MODEL():
             list_file = file_dir + self.modelname + '_list.txt'
             time_file = file_dir + self.modelname + '_times.txt'
             self.times, self.pattern_files = {}, {}
-            if not isfile(list_file) or not isfile(time_file):
+            if not RU._isfile(list_file) or not RU._isfile(time_file):
                 # collect filenames
-                files = sorted(glob(file_dir+'*.h5'))
+                files = sorted(RU.glob(file_dir+'*.h5'))
                 data_files = [f for f in files if 'Res' not in f]
                 self.filename = ''.join([f+',' for f in data_files])[:-1]
                 # one pattern per run: abcd_00nx_00ny_00nz
@@ -143,7 +140,7 @@ def MODEL():
                 self.times[p] = {'start': [], 'end': [], 'all': []}
 
                 # all times are in each file, so just use first file
-                h5_data = h5py.File(data_files[0])
+                h5_data = RU.h5py(data_files[0])
                 timestep_keys = [key for key in h5_data.keys()
                                  if 'Step' in key]
                 mjd_list = [h5_data[key].attrs['MJD'] for key in
@@ -206,7 +203,7 @@ def MODEL():
 
             # collect variable list (in attributes of datasets)
             p = list(self.pattern_files.keys())[0]  # only one pattern
-            h5_data = h5py.File(self.pattern_files[p][0])
+            h5_data = RU.h5py(self.pattern_files[p][0])
             key_list = [key for key in h5_data.keys() if 'Step' not in key and
                         key not in ['X', 'Y', 'Z']]  # skip coordinates
             step_list = list(h5_data['Step#0'].keys())
@@ -253,7 +250,7 @@ def MODEL():
                                             sample_var)
                 shape = net_indices['net'][1]  # shape of total array
             else:
-                h5_data = h5py.File(self.pattern_files[p][0])
+                h5_data = RU.h5py(self.pattern_files[p][0])
                 shape = list(h5_data['X'].shape)  # shape of total array
                 h5_data.close()
             self._X = linspace(X_min, X_max, endpoint=True, num=shape[0])
@@ -314,13 +311,13 @@ def MODEL():
                     block = 0  # default, but need this value from the interp
                     # read in data from block
                     file = self.pattern_files[key][block]
-                    h5_data = h5py.File(file)
+                    h5_data = RU.h5py(file)
                     data = array(h5_data['Step#'+str(fi)][gvar])
                     h5_data.close()
                     # read in cell centers for requested block
                     center_file = file_dir + basename(file).split('.')[0] +\
                         '_gridcenters.nc'
-                    cdf_data = Dataset(center_file)
+                    cdf_data = RU.Dataset(center_file)
                     X_c = array(cdf_data['X_c'])
                     Y_c = array(cdf_data['Y_c'])
                     Z_c = array(cdf_data['Z_c'])
@@ -358,13 +355,13 @@ def MODEL():
                     block = 0  # default, but need this value from the interp
                     # read in data from block
                     file = self.pattern_files[key][block]
-                    h5_data = h5py.File(file)
+                    h5_data = RU.h5py(file)
                     data = array(h5_data[gvar])
                     h5_data.close()
                     # read in cell centers for requested block
                     center_file = file_dir + basename(file).split('.')[0] +\
                         '_gridcenters.nc'
-                    cdf_data = Dataset(center_file)
+                    cdf_data = RU.Dataset(center_file)
                     X_c = array(cdf_data['X_c'])
                     Y_c = array(cdf_data['Y_c'])
                     Z_c = array(cdf_data['Z_c'])

--- a/kamodo_ccmc/readers/iri_4D.py
+++ b/kamodo_ccmc/readers/iri_4D.py
@@ -53,7 +53,6 @@ model_varnames = {'Ne': ['N_e', 'electron number density',
 def MODEL():
 
     from kamodo import Kamodo
-    from netCDF4 import Dataset
     from os.path import basename
     from numpy import array, transpose, NaN, unique
     from numpy import where, append
@@ -131,7 +130,8 @@ def MODEL():
 
                     # loop through to get times
                     for f in range(len(pattern_files)):
-                        cdf_data = Dataset(pattern_files[f])
+                        cdf_data = RU.Dataset(pattern_files[f],
+                                              filetype='netCDF3')
                         tmp = array(cdf_data.variables['time'])/60. + \
                             float(f)*24.  # hrs since midnite 1st file
                         self.times[p]['start'].append(tmp[0])
@@ -173,7 +173,8 @@ def MODEL():
             self.gvarfiles, self.varfiles, self.err_list = {}, {}, []
             for p in self.pattern_files.keys():
                 # check var_list for variables not possible in this file set
-                cdf_data = Dataset(self.pattern_files[p][0], 'r')
+                cdf_data = RU.Dataset(self.pattern_files[p][0],
+                                      filetype='netCDF3')
                 if len(variables_requested) > 0 and\
                         variables_requested != 'all':
                     gvar_list = [key for key in model_varnames.keys()
@@ -214,7 +215,8 @@ def MODEL():
             self.variables = {}
             for p in self.pattern_files.keys():
                 # get coordinates from first file of each type
-                cdf_data = Dataset(self.pattern_files[p][0], 'r')
+                cdf_data = RU.Dataset(self.pattern_files[p][0],
+                                      filetype='netCDF3')
                 lon = array(cdf_data.variables['lon'])
                 lon_le180 = list(where(lon <= 180)[0])  # 0 to 180
                 lon_ge180 = list(where((lon >= 180) & (lon < 360.))[0])
@@ -285,7 +287,7 @@ def MODEL():
                 '''
                 # get data from file
                 file = self.pattern_files[key][i]
-                cdf_data = Dataset(file)
+                cdf_data = RU.Dataset(file, filetype='netCDF3')
                 data = array(cdf_data.variables[gvar])
                 if hasattr(cdf_data.variables[gvar][0], 'fill_value'):
                     fill_value = cdf_data.variables[gvar][0].fill_value
@@ -295,7 +297,7 @@ def MODEL():
                 # if not the last file, tack on first time from next file
                 if file != self.pattern_files[key][-1]:  # interp btwn files
                     next_file = self.pattern_files[key][i+1]
-                    cdf_data = Dataset(next_file)
+                    cdf_data = RU.Dataset(next_file, filetype='netCDF3')
                     data_slice = array(cdf_data.variables[gvar][0])
                     cdf_data.close()
                     data = append(data, [data_slice], axis=0)

--- a/kamodo_ccmc/readers/iri_4D.py
+++ b/kamodo_ccmc/readers/iri_4D.py
@@ -54,8 +54,7 @@ def MODEL():
 
     from kamodo import Kamodo
     from netCDF4 import Dataset
-    from glob import glob
-    from os.path import basename, isfile
+    from os.path import basename
     from numpy import array, transpose, NaN, unique
     from numpy import where, append
     from time import perf_counter
@@ -117,16 +116,16 @@ def MODEL():
             list_file = file_dir + self.modelname + '_list.txt'
             time_file = file_dir + self.modelname + '_times.txt'
             self.times, self.pattern_files = {}, {}
-            if not isfile(list_file) or not isfile(time_file):
+            if not RU._isfile(list_file) or not RU._isfile(time_file):
                 # collect filenames
-                files = sorted(glob(file_dir+'*.nc'))
+                files = sorted(RU.glob(file_dir+'*.nc'))
                 patterns = unique([basename(f)[:-10] for f in files])  # 2D, 3D
                 self.filename = ''.join([f+',' for f in files])[:-1]
 
                 # establish time attributes
                 for p in patterns:
                     # get list of files to loop through later
-                    pattern_files = sorted(glob(file_dir+p+'*.nc'))
+                    pattern_files = sorted(RU.glob(file_dir+p+'*.nc'))
                     self.pattern_files[p] = pattern_files
                     self.times[p] = {'start': [], 'end': [], 'all': []}
 

--- a/kamodo_ccmc/readers/openggcm_gm_4Dcdf.py
+++ b/kamodo_ccmc/readers/openggcm_gm_4Dcdf.py
@@ -45,7 +45,7 @@ model_varnames = {'bx': ['B_x', 'x component of magnetic field',
 def MODEL():
     from numpy import array, unique, squeeze
     from time import perf_counter
-    from os.path import isfile, basename
+    from os.path import basename
     from kamodo import Kamodo
     import kamodo_ccmc.readers.reader_utilities as RU
 
@@ -115,7 +115,7 @@ def MODEL():
             list_file = file_dir + self.modelname + '_list.txt'
             time_file = file_dir + self.modelname + '_times.txt'
             self.times, self.pattern_files = {}, {}
-            if not isfile(list_file) or not isfile(time_file):
+            if not RU._isfile(list_file) or not RU._isfile(time_file):
                 # collect filenames
                 files = sorted(RU.glob(file_dir+'*.nc'))
                 if len(files) == 0:

--- a/kamodo_ccmc/readers/reader_utilities.py
+++ b/kamodo_ccmc/readers/reader_utilities.py
@@ -24,7 +24,7 @@ def Dataset(filename, access='r'):
         - access: 'r' for read, 'w' for write
     Output: a Dataset object that behaves similarly to netCDF4's Dataset object
     '''
-    if filename[:2] == 's3':
+    if filename[:5] == 's3://':
         s3=s3fs.S3FileSystem(anon=False)
         fgrab = s3.open(filename, access+'b')
         return Dataset_leg(fgrab)

--- a/kamodo_ccmc/readers/reader_utilities.py
+++ b/kamodo_ccmc/readers/reader_utilities.py
@@ -24,8 +24,8 @@ def Dataset(filename, access='r'):
         - access: 'r' for read, 'w' for write
     Output: a Dataset object that behaves similarly to netCDF4's Dataset object
     '''
-    if filename[:5] == 's3://':
-        s3=s3fs.S3FileSystem(anon=False)
+    if filename[:2] == 's3':
+        s3 = s3fs.S3FileSystem(anon=False)
         fgrab = s3.open(filename, access+'b')
         return Dataset_leg(fgrab)
     else:

--- a/kamodo_ccmc/readers/superdarnuni_4D.py
+++ b/kamodo_ccmc/readers/superdarnuni_4D.py
@@ -1,7 +1,7 @@
 '''
 Written by Rebecca Ringuette, 2021
 '''
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 # variable name in file: [standardized variable name, descriptive term, units]
 model_varnames = {"V": ['V', 'Electric potential', 0, 'SM', 'sph',
@@ -27,9 +27,7 @@ model_varnames = {"V": ['V', 'Electric potential', 0, 'SM', 'sph',
 def MODEL():
 
     from kamodo import Kamodo
-    from netCDF4 import Dataset
-    from glob import glob
-    from os.path import basename, isfile
+    from os.path import basename
     from numpy import array, NaN, unique
     from time import perf_counter
     import kamodo_ccmc.readers.reader_utilities as RU
@@ -102,14 +100,14 @@ def MODEL():
             list_file = file_dir + self.modelname + '_list.txt'
             time_file = file_dir + self.modelname + '_times.txt'
             self.times, self.pattern_files = {}, {}
-            if not isfile(list_file) or not isfile(time_file):
+            if not RU._isfile(list_file) or not RU._isfile(time_file):
                 # make sure all files are converted
                 from kamodo_ccmc.readers.superdarn_tocdf import \
                     convert_all
                 tmp = convert_all(file_dir, '*uni.txt')
 
                 # continue with converted files
-                files = sorted(glob(file_dir+'*_uni.nc'))
+                files = sorted(RU.glob(file_dir+'*_uni.nc'))
                 self.filename = ''.join([f+',' for f in files])[:-1]
                 patterns = unique([basename(f)[:-20] for f in files])
                 self.filedate = datetime.strptime(
@@ -119,7 +117,7 @@ def MODEL():
                 # establish time attributes from filenames
                 for p in patterns:
                     # get list of files to loop through later
-                    pattern_files = sorted(glob(file_dir+p+'*_uni.nc'))
+                    pattern_files = sorted(RU.glob(file_dir+p+'*_uni.nc'))
                     self.pattern_files[p] = pattern_files
                     self.times[p] = {'start': [], 'end': [], 'all': []}
                     if pattern_files[0][-12] == '-':
@@ -146,7 +144,7 @@ def MODEL():
                 return  # return times
             # only one pattern, so simplifying code
             p = list(self.pattern_files.keys())[0]
-            cdf_data = Dataset(self.pattern_files[p][0])
+            cdf_data = RU.Dataset(self.pattern_files[p][0])
 
             # perform initial check on variables_requested list
             if len(variables_requested) > 0 and variables_requested != 'all':
@@ -164,7 +162,7 @@ def MODEL():
             if len(variables_requested) > 0 and variables_requested != 'all':
                 gvar_list = [key for key, value in model_varnames.items()
                              if value[0] in variables_requested and
-                             key in cdf_data.variables.keys()]
+                             key in cdf_data.keys()]
 
                 # check for variables requested but not available
                 if len(gvar_list) != len(variables_requested):
@@ -175,7 +173,7 @@ def MODEL():
                         print('Some requested variables are not available:',
                               err_list)
             else:  # only input variables on the avoid_list if requested
-                gvar_list = [key for key in cdf_data.variables.keys()
+                gvar_list = [key for key in cdf_data.keys()
                              if key in model_varnames.keys()]
                 # returns list of variables included in data files
                 if variables_requested == 'all':
@@ -191,8 +189,8 @@ def MODEL():
                 gvar_list}
 
             # Store coordinate data as class attributes
-            self._lon = array(cdf_data.variables['lon'])  # -180 to 180
-            self._lat = array(cdf_data.variables['lat'])
+            self._lon = array(cdf_data['lon'])  # -180 to 180
+            self._lat = array(cdf_data['lat'])
             cdf_data.close()
 
             # store a few items
@@ -237,8 +235,8 @@ def MODEL():
             if len(coord_list) == 1:  # read in entire time series
                 data = []
                 for f in self.pattern_files[key]:
-                    cdf_data = Dataset(f)
-                    tmp = array(cdf_data.variables[gvar])[0]
+                    cdf_data = RU.Dataset(f)
+                    tmp = array(cdf_data[gvar])[0]
                     cdf_data.close()
                     data.append(tmp)  # one value per file
                 self.variables[varname]['data'] = array(data)
@@ -256,9 +254,9 @@ def MODEL():
                     '''i is the file/time number.'''
                     # get data from file
                     file = self.pattern_files[key][i]
-                    cdf_data = Dataset(file)
-                    data = array(cdf_data.variables[gvar])
-                    lat = array(cdf_data.variables['lat'])
+                    cdf_data = RU.Dataset(file)
+                    data = array(cdf_data[gvar])
+                    lat = array(cdf_data['lat'])
                     cdf_data.close()
                     # data wrangling all done in the file conversion step
                     coord_list = [coord_dict['lon']['data'], lat]

--- a/kamodo_ccmc/readers/swmfie_4Dcdf.py
+++ b/kamodo_ccmc/readers/swmfie_4Dcdf.py
@@ -72,9 +72,7 @@ left in files, not in kamodo object
 
 def MODEL():
     from numpy import array, unique
-    from glob import glob
     from time import perf_counter
-    from netCDF4 import Dataset
     from kamodo import Kamodo
     import kamodo_ccmc.readers.reader_utilities as RU
 
@@ -137,10 +135,10 @@ def MODEL():
             list_file = file_dir + self.modelname + '_list.txt'
             time_file = file_dir + self.modelname + '_times.txt'
             self.times, self.pattern_files = {}, {}
-            if not isfile(list_file) or not isfile(time_file):
+            if not RU._isfile(list_file) or not RU._isfile(time_file):
                 # find unconverted files and convert them
-                nc_files = sorted(glob(file_dir+'*.nc'))
-                tec_files = sorted(glob(file_dir+'*.tec'))
+                nc_files = sorted(RU.glob(file_dir+'*.nc'))
+                tec_files = sorted(RU.glob(file_dir+'*.tec'))
                 if len(nc_files) != len(tec_files) and len(tec_files) > 0:
                     from kamodo_ccmc.readers.swmfie_tocdf import \
                         convert_all
@@ -149,7 +147,7 @@ def MODEL():
                     print('All files already converted.')
 
                 # continue
-                files = sorted(glob(file_dir+'*.nc'))
+                files = sorted(RU.glob(file_dir+'*.nc'))
                 patterns = unique([basename(f)[:-22] for f in files])
                 self.filename = ''.join([f+',' for f in files])[:-1]
                 self.filedate = datetime.strptime(
@@ -159,7 +157,7 @@ def MODEL():
                 # establish time attributes from filenames
                 for p in patterns:
                     # get list of files to loop through later
-                    pattern_files = sorted(glob(file_dir+p+'*.nc'))
+                    pattern_files = sorted(RU.glob(file_dir+p+'*.nc'))
                     self.pattern_files[p] = pattern_files
                     self.times[p] = {'start': [], 'end': [], 'all': []}
 
@@ -185,7 +183,7 @@ def MODEL():
                 return  # return times as is to prevent infinite recursion
             # only one pattern, so simplifying code
             p = list(self.pattern_files.keys())[0]
-            cdf_data = Dataset(self.pattern_files[p][0])
+            cdf_data = RU.Dataset(self.pattern_files[p][0])
 
             # perform initial check on variables_requested list
             if len(variables_requested) > 0 and variables_requested != 'all':
@@ -277,7 +275,7 @@ def MODEL():
                 '''i is the file number.'''
                 # get data from file
                 file = self.pattern_files[key][i]
-                cdf_data = Dataset(file)
+                cdf_data = RU.Dataset(file)
                 data = array(cdf_data.variables[gvar])
                 cdf_data.close()
                 # data wrangling all done in the file conversion step

--- a/kamodo_ccmc/readers/waccmx_4D.py
+++ b/kamodo_ccmc/readers/waccmx_4D.py
@@ -411,7 +411,6 @@ def MODEL():
     from kamodo import Kamodo
     from os.path import getsize
     import psutil
-    from netCDF4 import Dataset
     from numpy import array, NaN, where, unique, append, linspace
     from numpy import transpose, median
     from time import perf_counter
@@ -524,7 +523,8 @@ def MODEL():
 
                     # loop through to get times
                     for f in range(len(pattern_files)):
-                        cdf_data = Dataset(pattern_files[f])
+                        cdf_data = RU.Dataset(pattern_files[f],
+                                              filetype='netCDF3')
                         # hours since midnight first file
                         tmp = array(cdf_data.variables['time'])
                         pmt = array(cdf_data.variables['datesec'])
@@ -619,7 +619,8 @@ def MODEL():
             self.variables = {}
             for key in self.pattern_files.keys():
                 # collect dimensions from first file
-                cdf_datah = Dataset(self.pattern_files[key][0])
+                cdf_datah = RU.Dataset(self.pattern_files[key][0],
+                                       filetype='netCDF3')
                 for dim in cdf_datah.dimensions.keys():
                     # deal with dim renaming and skipping
                     if dim == 'ilev':
@@ -654,7 +655,7 @@ def MODEL():
                 if 'h0' in key:
                     km_max, km_min, km = [], [], []
                     for f in self.pattern_files[key]:
-                        cdf_datah0 = Dataset(f)
+                        cdf_datah0 = RU.Dataset(f, filetype='netCDF3')
                         km.append(array(cdf_datah0.variables['km_ilev']))
                         km_max.append(cdf_datah0.km_ilev_max)
                         km_min.append(cdf_datah0.km_ilev_min)
@@ -734,7 +735,8 @@ def MODEL():
                 - hx_files: a list of files for a given day.
             '''
             if h_type in file_dict.keys():
-                cdf_datah = Dataset(file_dict[h_type][0])
+                cdf_datah = RU.Dataset(file_dict[h_type][0],
+                                       filetype='netCDF3')
                 cdf_datah_keys = list(cdf_datah.variables.keys())
                 cdf_datah.close()
                 gvar_listh = self.variable_checks(variables_requested,
@@ -754,7 +756,8 @@ def MODEL():
                     given file type.
             '''
             if h_type in file_dict.keys():
-                cdf_datah = Dataset(file_dict[h_type][0])
+                cdf_datah = RU.Dataset(file_dict[h_type][0],
+                                       filetype='netCDF3')
                 gvar_listh = [key for key, value in model_varnames.items()
                               if key in cdf_datah.variables.keys() and key in
                               g_varkeys_h]
@@ -781,7 +784,7 @@ def MODEL():
             if len(coord_list) == 1:  # convert 1D to array and functionalize
                 data = []
                 for f in self.pattern_files[key]:
-                    cdf_data = Dataset(f)
+                    cdf_data = RU.Dataset(f, filetype='netCDF3')
                     tmp = array(cdf_data.variables[gvar])
                     cdf_data.close()
                     data.extend(tmp)
@@ -811,7 +814,8 @@ def MODEL():
                 # save memory by only retrieving time slices from the files
                 # determine the operation to occur on each time slice
                 def func(i, fi):  # i = file#, fi = slice#
-                    cdf_data = Dataset(self.pattern_files[key][i])
+                    cdf_data = RU.Dataset(self.pattern_files[key][i],
+                                          filetype='netCDF3')
                     tmp = array(cdf_data.variables[gvar][fi])
                     cdf_data.close()
                     # perform data wrangling on time slice
@@ -829,7 +833,8 @@ def MODEL():
                 # determine the operation to occur on each time chunk
                 def func(f):  # file_idx
                     # convert slice number s to index in file
-                    cdf_data = Dataset(self.pattern_files[key][f])
+                    cdf_data = RU.Dataset(self.pattern_files[key][f],
+                                          filetype='netCDF3')
                     tmp = array(cdf_data.variables[gvar])
                     cdf_data.close()
                     # perform data wrangling on time chunk

--- a/kamodo_ccmc/readers/waccmx_4D.py
+++ b/kamodo_ccmc/readers/waccmx_4D.py
@@ -409,11 +409,10 @@ ilev_replace = [item.split('_ilev')[0] for item in ilev_list if
 def MODEL():
 
     from kamodo import Kamodo
-    from glob import glob
-    from os.path import isfile, getsize
+    from os.path import getsize
     import psutil
     from netCDF4 import Dataset
-    from numpy import array, NaN, zeros, where, unique, append, linspace
+    from numpy import array, NaN, where, unique, append, linspace
     from numpy import transpose, median
     from time import perf_counter
     from datetime import datetime, timezone
@@ -500,9 +499,9 @@ def MODEL():
             list_file = file_dir + self.modelname + '_list.txt'
             time_file = file_dir + self.modelname + '_times.txt'
             self.times, self.pattern_files = {}, {}
-            if not isfile(list_file) or not isfile(time_file):
+            if not RU._isfile(list_file) or not RU._isfile(time_file):
                 # collect filenames
-                files = sorted(glob(file_dir+'*.h?.*.nc'))
+                files = sorted(RU.glob(file_dir+'*.h?.*.nc'))
                 patterns = unique([file[-22:-20] for file in files])
                 self.filename = ''.join([f+',' for f in files])[:-1]
                 self.filedate = datetime.strptime(
@@ -519,7 +518,7 @@ def MODEL():
                 # establish time attributes
                 for p in patterns:
                     # get list of files to loop through later
-                    pattern_files = sorted(glob(file_dir+'*.'+p+'.*.nc'))
+                    pattern_files = sorted(RU.glob(file_dir+'*.'+p+'.*.nc'))
                     self.pattern_files[p] = pattern_files
                     self.times[p] = {'start': [], 'end': [], 'all': []}
 

--- a/kamodo_ccmc/readers/wamipe_4D.py
+++ b/kamodo_ccmc/readers/wamipe_4D.py
@@ -108,7 +108,6 @@ def MODEL():
     from time import perf_counter
     from os.path import basename
     from numpy import array, unique, NaN, append, linspace, where, squeeze
-    from netCDF4 import Dataset
     from kamodo import Kamodo
     import kamodo_ccmc.readers.reader_utilities as RU
 
@@ -288,7 +287,8 @@ def MODEL():
             self.err_list, self.var_dict = [], {}
             for p in self.pattern_files.keys():
                 # check var_list for variables not possible in this file set
-                cdf_data = Dataset(self.pattern_files[p][0], 'r')
+                cdf_data = RU.Dataset(self.pattern_files[p][0],
+                                      filetype='netCDF3')
                 if len(variables_requested) > 0 and \
                         variables_requested != 'all':
                     gvar_list = [key for key, value in model_varnames.items()
@@ -363,7 +363,7 @@ def MODEL():
                     if 'height' in cdf_data.variables.keys():
                         h0_file = self.pattern_files[p][0][:-18] + 'h0.nc'
                         if RU._isfile(h0_file):
-                            cdf_h = Dataset(h0_file)
+                            cdf_h = RU.Dataset(h0_file, filetype='netCDF3')
                             self._km_ilev = array(cdf_h.variables['km_ilev'])
                             self._km_ilev_max = cdf_h.km_max
                             self._km_ilev_min = cdf_h.km_min
@@ -455,7 +455,7 @@ def MODEL():
                 '''i is the time slice. WAM-IPE has one time slice per file.'''
                 # get data from file
                 file = self.pattern_files[key][i]
-                cdf_data = Dataset(file)
+                cdf_data = RU.Dataset(file, filetype='netCDF3')
                 data = array(cdf_data.variables[gvar])
                 # data wrangling
                 if hasattr(cdf_data.variables[gvar], '_FillValue'):

--- a/kamodo_ccmc/readers/wamipe_4D.py
+++ b/kamodo_ccmc/readers/wamipe_4D.py
@@ -106,8 +106,7 @@ model_varnames = {'den400': ['rho_400km', 'Density at 400 km.',
 
 def MODEL():
     from time import perf_counter
-    from glob import glob
-    from os.path import basename, isfile
+    from os.path import basename
     from numpy import array, unique, NaN, append, linspace, where, squeeze
     from netCDF4 import Dataset
     from kamodo import Kamodo
@@ -184,25 +183,25 @@ def MODEL():
             list_file = file_dir + self.modelname + '_list.txt'
             time_file = file_dir + self.modelname + '_times.txt'
             self.times, self.pattern_files = {}, {}
-            if not isfile(list_file) or not isfile(time_file):
+            if not RU._isfile(list_file) or not RU._isfile(time_file):
                 # collect filenames
-                files = sorted(glob(file_dir+'*.nc'))
+                files = sorted(RU.glob(file_dir+'*.nc'))
                 if len(files) == 0:  # find tar files and untar them
                     print('Decompressing files...this may take a moment.')
                     import tarfile
-                    tar_files = glob(file_dir+'*.tar')
+                    tar_files = RU.glob(file_dir+'*.tar')
                     for file in tar_files:
                         tar = tarfile.open(file)
                         tar.extractall(file_dir)
                         tar.close()
-                    files = sorted(glob(file_dir+'*.nc'))
+                    files = sorted(RU.glob(file_dir+'*.nc'))
 
                 # create h0 file containing km_ilev
                 from kamodo_ccmc.readers.wamipe_tocdf import convert_all
                 tmp = convert_all(file_dir)
 
                 # continue
-                files = sorted(glob(file_dir+'*.nc'))
+                files = sorted(RU.glob(file_dir+'*.nc'))
                 h0_file = [f for f in files if 'h0' in f]
                 if len(h0_file) > 0:
                     files.remove(h0_file[0])
@@ -215,7 +214,7 @@ def MODEL():
                 # establish time attributes from filenames
                 for p in patterns:
                     # get list of files to loop through later
-                    pattern_files = sorted(glob(file_dir+p+'*.nc'))
+                    pattern_files = sorted(RU.glob(file_dir+p+'*.nc'))
                     h0_file = [f for f in pattern_files if 'h0' in f]
                     if len(h0_file) > 0:
                         pattern_files.remove(h0_file[0])  # should be only one
@@ -349,7 +348,7 @@ def MODEL():
                         setattr(self, '_height_'+p,
                                 array(cdf_data.variables['hlevs']))  # km
                     setattr(self, '_heightunits_'+p, 'km')
-                # determine if pressure leve is needed (not included)
+                # determine if pressure level is needed (not included)
                 ilev_check = [True if 'ilev' in var else False for var in
                               self.varfiles[p]]
                 if sum(ilev_check) > 0:
@@ -363,7 +362,7 @@ def MODEL():
                     # get median km grid from h0 file, height only in h0 file
                     if 'height' in cdf_data.variables.keys():
                         h0_file = self.pattern_files[p][0][:-18] + 'h0.nc'
-                        if isfile(h0_file):
+                        if RU._isfile(h0_file):
                             cdf_h = Dataset(h0_file)
                             self._km_ilev = array(cdf_h.variables['km_ilev'])
                             self._km_ilev_max = cdf_h.km_max

--- a/kamodo_ccmc/readers/weimer_4D.py
+++ b/kamodo_ccmc/readers/weimer_4D.py
@@ -16,7 +16,6 @@ model_varnames = {'PHI': ['Phi', 'Electric potential', 0, 'SM', 'sph',
 def MODEL():
 
     from kamodo import Kamodo
-    from netCDF4 import Dataset
     from os.path import basename
     from numpy import array
     from time import perf_counter
@@ -95,7 +94,7 @@ def MODEL():
                 if len(txt_files) > 0:
                     self.filename = ''.join([f+',' for f in txt_files])[:-1]
                 else:
-                    cdf_data = Dataset(nc_files[0])
+                    cdf_data = RU.Dataset(nc_files[0], filetype='netCDF3')
                     txt_files = cdf_data.file.split(',')
                     cdf_data.close()
                 p = basename(nc_files[0]).split('.')[0]  # only one nc file
@@ -112,7 +111,7 @@ def MODEL():
                 self.times[p] = {'start': [], 'end': [], 'all': []}
 
                 # get times from single nc file
-                cdf_data = Dataset(nc_files[0])
+                cdf_data = RU.Dataset(nc_files[0], filetype='netCDF3')
                 tmp = array(cdf_data.variables['time'])  # hrs since midnit
                 self.times[p]['start'] = array([tmp[0]])
                 self.times[p]['end'] = array([tmp[-1]])
@@ -144,7 +143,7 @@ def MODEL():
 
             # collect variable list (in attributes of datasets)
             p = list(self.pattern_files.keys())[0]  # only one pattern
-            cdf_data = Dataset(self.pattern_files[p][0])
+            cdf_data = RU.Dataset(self.pattern_files[p][0], filetype='netCDF3')
 
             # get coordinates from first file
             self._lat = array(cdf_data.variables['lat'])
@@ -220,7 +219,8 @@ def MODEL():
                     value[0] == varname][0]  # variable name in file
 
             def func(i, fi):  # i = file#, fi = slice#
-                cdf_data = Dataset(self.pattern_files[key][i])
+                cdf_data = RU.Dataset(self.pattern_files[key][i],
+                                      filetype='netCDF3')
                 data = array(cdf_data.variables[gvar][fi])
                 cdf_data.close()
                 return data

--- a/kamodo_ccmc/readers/weimer_4D.py
+++ b/kamodo_ccmc/readers/weimer_4D.py
@@ -17,8 +17,7 @@ def MODEL():
 
     from kamodo import Kamodo
     from netCDF4 import Dataset
-    from glob import glob
-    from os.path import basename, isfile
+    from os.path import basename
     from numpy import array
     from time import perf_counter
     from datetime import datetime, timezone
@@ -85,15 +84,20 @@ def MODEL():
             list_file = file_dir + self.modelname + '_list.txt'
             time_file = file_dir + self.modelname + '_times.txt'
             self.times, self.pattern_files = {}, {}
-            if not isfile(list_file) or not isfile(time_file):
+            if not RU._isfile(list_file) or not RU._isfile(time_file):
                 # check for nc files
-                nc_files = sorted(glob(file_dir+'*.nc'))
-                txt_files = sorted(glob(file_dir+'*.txt'))
+                nc_files = sorted(RU.glob(file_dir+'*.nc'))
+                txt_files = sorted(RU.glob(file_dir+'*.txt'))
                 if len(nc_files) == 0:  # perform file conversion if none
                     from kamodo_ccmc.readers.weimer_tocdf import convert_all
                     convert_all(txt_files)
-                    nc_files = sorted(glob(file_dir+'*.nc'))
-                self.filename = ''.join([f+',' for f in txt_files])[:-1]
+                    nc_files = sorted(RU.glob(file_dir+'*.nc'))
+                if len(txt_files) > 0:
+                    self.filename = ''.join([f+',' for f in txt_files])[:-1]
+                else:
+                    cdf_data = Dataset(nc_files[0])
+                    txt_files = cdf_data.file.split(',')
+                    cdf_data.close()
                 p = basename(nc_files[0]).split('.')[0]  # only one nc file
 
                 # datetime object for midnight on date from first text file


### PR DESCRIPTION
This pull request addresses [issue #130](https://github.com/nasa/Kamodo/issues/130) and enables interpolation through data stored in s3 buckets. Supported data types include h5, netCDF3, and netCDF4. All model readers have been tested both on normal data storage and in s3 buckets, with the exception noted in [this issue](https://github.com/EnsembleGovServices/kamodo-core/issues/113). File conversions on s3 buckets are not supported as the user is not expected to have write permissions. In order to prepare the modelname_list.txt file creation, see [this notebook](https://github.com/rebeccaringuette/MagnetopauseExecutablePaper/blob/main/DataPreparation.ipynb). 
This PR removes the dependency on h5py, but adds dependencies on boto3, h5netcdf, and s3fs. Note that the environment must be constructed carefully, restricting s3fs to versions less than 0.5.0 to avoid a dependency conflict [see this issue](https://github.com/fsspec/s3fs/issues/357).  The order below works in Python 3.10 after installing pyspedas and plasmapy.
```
pip install "s3fs<0.5.0"
pip install boto3
pip install h5netcdf
pip install ./Kamodo
```
An example yml file, conda list, and instructions are located at [this repo](https://github.com/rebeccaringuette/MagnetopauseExecutablePaper). The environment described includes pyspedas, plasmapy, spacepy, and kamodo-ccmc in Python 3.10.10.