### PR TITLE
SWMF GM reader: Avoid rescaling data that already have been written with proper units.

### DIFF
--- a/kamodo_ccmc/readers/OCTREE_BLOCK_GRID/setup_octree.h
+++ b/kamodo_ccmc/readers/OCTREE_BLOCK_GRID/setup_octree.h
@@ -5,3 +5,9 @@ void   setup_octree(IDL_LONG N_blks_in,
 		    IDL_LONG N_octree_blocks,
 		    IDL_LONG *numparents_at_AMRlevel_in,
 		    IDL_LONG *block_at_AMRlevel_in);
+void setup_octree_pointers(
+                        IDL_LONG MAX_AMRLEVELS_in,
+                        octree_block *octree_blocklist_in,
+                        IDL_LONG *numparents_at_AMRlevel_in,
+                        IDL_LONG *block_at_AMRlevel_in);
+


### PR DESCRIPTION
The SWMF GM reader has been corrected to only apply scaling factor to dimensionless outputs as indicated in the list of units provided with the data. 
A keyword implemented in pybats.IdlFile() in a branch of SpacePy was removed as the desired functionality is the default since SpacePy version 0.5.0.