### PR TITLE
Kamodo-JB2008 tool addition

### DIFF
--- a/dockerfiles/dockerfile_jb2008
+++ b/dockerfiles/dockerfile_jb2008
@@ -1,0 +1,50 @@
+FROM  condaforge/miniforge3:latest
+LABEL maintainer "Asher Pembroke <apembroke@gmail.com>"
+
+# Update and install build-essential and curl
+RUN DEBIAN_FRONTEND="noninteractive" apt-get update && apt-get install -y \
+    gfortran \
+    build-essential \
+    curl
+
+WORKDIR /
+
+# kamodo-core
+RUN git clone https://github.com/asherp/kamodo-core.git
+RUN pip install /kamodo-core
+
+RUN git clone https://github.com/pengmun/DESTOPy.git
+
+RUN conda install h5py
+
+WORKDIR /DESTOPy
+
+RUN pip install -r requirements.txt
+
+WORKDIR /jb2008
+
+COPY kamodo_ccmc/readers/kamodo-JB2008/requirements.txt .
+RUN pip install -r requirements.txt
+
+WORKDIR /DESTOPy/Data
+
+RUN wget https://naif.jpl.nasa.gov/pub/naif/generic_kernels/lsk/latest_leapseconds.tls
+RUN wget https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de430.bsp
+RUN wget https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/stations/earthstns_itrf93_201023.bsp
+RUN wget https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/pck00010.tpc
+RUN wget https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_fixed.tf
+RUN wget https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/a_old_versions/earth_200101_990628_predict.bpc
+RUN wget -O earth_000101_210530_210308.bpc https://naif.jpl.nasa.gov/pub/naif/MEX/kernels/pck/former_versions/EARTH_000101_210530_210308.BPC
+RUN wget https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/a_old_versions/earth_720101_070426.bpc
+RUN wget https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_latest_high_prec.bpc
+RUN wget https://www.celestrak.com/SpaceData/SW-All.txt
+RUN wget https://www.celestrak.com/SpaceData/EOP-All.txt
+RUN wget -O SOLFSMY.txt https://sol.spacenvironment.net/JB2008/indices/SOLFSMY.TXT
+RUN wget -O DTCFILE.txt https://sol.spacenvironment.net/JB2008/indices/DTCFILE.TXT
+
+COPY kernel.txt /DESTOPy/Data/kernel.txt
+
+WORKDIR /jb2008
+
+COPY . .
+

--- a/kamodo_ccmc/readers/kamodo-JB2008/README.md
+++ b/kamodo_ccmc/readers/kamodo-JB2008/README.md
@@ -1,0 +1,64 @@
+
+# Kamodo-JB2008
+
+This is a kamodo wrapper for the JB2008 model.
+
+We are building on the Destopy library.
+
+To get started, clone this repo
+
+<!-- #region -->
+```sh
+git clone git@github.com:EnsembleGovServices/kamodo-JB2008.git
+cd kamodo-JB2008
+```
+<!-- #endregion -->
+
+# Building with compose
+
+
+Build with compose:
+
+<!-- #region -->
+```sh
+docker compose build jb2008
+```
+<!-- #endregion -->
+
+```python
+from jb.jb08 import KJB08
+
+import datetime
+import numpy as np
+from plotly.offline import init_notebook_mode
+import plotly.graph_objs as go
+```
+
+```python
+kj = KJB08()
+kj
+```
+
+```python
+alt = 400
+lon = 0
+lat = -90
+
+my_date = datetime.datetime(2023, 4, 1, 1, 8, 0, 0)
+
+kj.rho(lon, lat, alt, my_date)
+```
+
+```python
+dens = []
+lons = np.linspace(-180, 180, 300)
+for lon in lons:
+    dens.append(kj.rho(lon, 70, alt, my_date))
+    
+init_notebook_mode(connected=True)
+go.Figure(go.Scatter(x=lons, y=dens))
+```
+
+```python
+
+```

--- a/kamodo_ccmc/readers/kamodo-JB2008/WorkLog.md
+++ b/kamodo_ccmc/readers/kamodo-JB2008/WorkLog.md
@@ -1,0 +1,20 @@
+* datetime input
+* got kamodofied density function working
+# 2024-05-23 17:25:50.839425: clock-out: T-10m 
+
+* separate notebook container for development, test density calculation
+
+# 2024-05-23 15:51:01.682497: clock-in
+
+# 2024-05-21 13:57:44.876741: clock-out
+
+Working session with Don, Jeff
+* built and ran jb2008
+* Got SO_Propagation to run
+
+Next steps:
+* how do we use this in production?
+* do we use their flythrough capability?
+
+# 2024-05-21 12:38:24.321656: clock-in
+

--- a/kamodo_ccmc/readers/kamodo-JB2008/docker-compose.yaml
+++ b/kamodo_ccmc/readers/kamodo-JB2008/docker-compose.yaml
@@ -1,0 +1,37 @@
+version: "3.9"
+
+services:
+  jb2008:
+    image: ensemble/jb2008
+    build:
+      context: ../../../
+      dockerfile: dockerfiles/dockerfile_JB2008
+    volumes:
+      - .:/jb2008
+    ports:
+      - "8887:8887"
+    command:
+      - jupyter
+      - notebook
+      - /jb2008
+      - --port=8887
+      - --no-browser
+      - --ip=0.0.0.0
+      - --allow-root
+  destopy:
+    image: ensemble/jb2008
+    build:
+      context: ../../../
+      dockerfile: dockerfiles/dockerfile_JB2008
+    volumes:
+      - .:/jb2008
+    ports:
+      - "8889:8889"
+    command:
+      - jupyter
+      - notebook
+      - /DESTOPy
+      - --port=8889
+      - --no-browser
+      - --ip=0.0.0.0
+      - --allow-root

--- a/kamodo_ccmc/readers/kamodo-JB2008/jb/jb08.py
+++ b/kamodo_ccmc/readers/kamodo-JB2008/jb/jb08.py
@@ -1,0 +1,88 @@
+# +
+import sys
+sys.path.append('/DESTOPy')
+
+from python_utils.astro_function_jit import generateObservationsMEE, generateROMdensityModel, getDensityJB2008llajd, ep2pv_jit, UKF, readDTCFILE, from_jd, getTLEsForEstimation, propagateState_MeeBcRom
+from python_utils.astro_function_jit import inputEOP_Celestrak_Full, readSOLFSMY, readDTCFILE
+from python_utils.astro_function_jit import computeJB2000SWinputs, get_julian_datetime
+from python_utils.JB2008_subfunc import JB2008
+import spiceypy as spice
+
+import numpy as np
+import datetime
+from kamodo import Kamodo, kamodofy
+
+
+# -
+
+class KJB08(Kamodo): 
+    """Kamodofied JB2008 model"""
+    def __init__(self, **kwargs):
+        ## Load space weather data and Earth orientation parameters needed for JB2008 density model from file
+        # Read Earth orientation parameters
+        # need to specify the full path to these files
+        spice.furnsh("/DESTOPy/Data/kernel.txt")
+        
+        self._eopdata = inputEOP_Celestrak_Full('/DESTOPy/Data/EOP-All.txt')
+
+        # Read space weather data: solar activity indices
+        self._SOLdata = readSOLFSMY('/DESTOPy/Data/SOLFSMY.txt')
+
+        # Read geomagnetic storm DTC values
+        self._DTCdata = readDTCFILE('/DESTOPy/Data/DTCFILE.txt')
+
+    
+        super(KJB08, self).__init__(**kwargs)
+        
+        @kamodofy(units='kg/m^3')
+        def jb2008_density(lon, lat, alt, t):
+            eop = self._eopdata  
+            sol = self._SOLdata 
+            dtc = self._DTCdata
+            
+            jd = get_julian_datetime(t)
+            
+            TEMP1, TEMP2, dens = self.getDensityJB2008llajd(lon, lat, alt, jd)
+                        
+            return dens
+            
+        self['rho'] = jb2008_density
+
+    def getDensityJB2008llajd(self, lon, lat, alt, jdate):
+        """
+        Compute density of a particular point in atmosphere based on JB2008 density model and space weather input
+
+        """
+        eopdata = self._eopdata
+        SOLdata = self._SOLdata
+        DTCdata = self._DTCdata
+        
+        # Date and time
+        dt_jdf = from_jd(np.ceil(round(jdate * 1e7,7))/ 1e7);  # End date of TLE collection window 
+        yyUTC = dt_jdf.year
+        mmUTC = dt_jdf.month
+        ddUTC = dt_jdf.day
+        hhUTC = dt_jdf.hour
+        mnmnUTC = dt_jdf.minute
+        ssUTC = dt_jdf.second
+
+        doyUTC = dt_jdf.timetuple().tm_yday
+
+        # Get JB2008 space weather data
+        MJD,GWRAS,SUN,F10,F10B,S10,S10B,XM10,XM10B,Y10,Y10B,DSTDTC = computeJB2000SWinputs(yyUTC,doyUTC,hhUTC,mnmnUTC,ssUTC,SOLdata,DTCdata,eopdata,spice);
+
+        SAT = np.zeros((3,1))
+        XLON = np.deg2rad(lon); # Lon
+        SAT[0] = np.mod(GWRAS + XLON, 2*np.pi);
+        SAT[1] = np.deg2rad(lat); # Lat
+        SAT[2] = alt;
+
+        YRDAY = doyUTC + ((hhUTC*3600 + mnmnUTC*60 + ssUTC) / 86400)
+        (TEMP1, TEMP2), rho = JB2008(MJD,YRDAY,SUN.flatten(),SAT.flatten(),F10,F10B,S10,S10B,XM10,XM10B,Y10,Y10B,DSTDTC)
+
+        return TEMP1, TEMP2, rho
+
+
+
+
+

--- a/kamodo_ccmc/readers/kamodo-JB2008/kernel.txt
+++ b/kamodo_ccmc/readers/kamodo-JB2008/kernel.txt
@@ -1,0 +1,27 @@
+\begindata
+
+KERNELS_TO_LOAD = ('/DESTOPy/Data/latest_leapseconds.tls',
+                   '/DESTOPy/Data/de430.bsp',
+                   '/DESTOPy/Data/pck00010.tpc',
+                   '/DESTOPy/Data/earth_fixed.tf',
+                   '/DESTOPy/Data/earthstns_itrf93_201023.bsp',
+                   '/DESTOPy/Data/earth_200101_990628_predict.bpc',
+                   '/DESTOPy/Data/earth_000101_210530_210308.bpc',
+                   '/DESTOPy/Data/earth_latest_high_prec.bpc',
+                   '/DESTOPy/Data/earth_720101_070426.bpc')
+
+\begintext
+
+DESCRIPTION:
+latest_leapseconds.tls              Leapseconds kernel
+de430.bsp                           Planet and Lunar Ephemerides
+pck00010.tpc                        Orientation of main bodies & physical constants (PCK)
+earth_fixed.tf                      Earth fixed frame transformations
+earthstns_itrf93_201023.bsp         Station locations in ITRF93
+earth_200101_990628_predict.bpc     Predicted Earth orientation parameters (01-Jan-2001 to 28-Jun-1999)
+earth_000101_210530_210308.bpc      High precision Earth orientation parameters (01-Jan-2000 to 30-May-2105)
+earth_latest_high_prec.bpc          Latest high precision Earth orientation parameters
+earth_720101_070426.bpc             High precision Earth orientation parameters (01-Jan-1972 to 26-Apr-2007)
+
+.bsp      == binary format
+.tpc, .tf == text format

--- a/kamodo_ccmc/readers/kamodo-JB2008/requirements.txt
+++ b/kamodo_ccmc/readers/kamodo-JB2008/requirements.txt
@@ -1,0 +1,9 @@
+mkdocs
+numpy==1.26.4
+python-markdown-math
+markdown-include
+pygments
+mkdocs-material
+jupyter
+jupytext
+notebook==6.4.*


### PR DESCRIPTION
Ensemble has added a Kamodo-JB2008 model reader; the Kamodo object that's built can query for instantaneous neutral density readings.

The tool is constructed using Docker; to build, clone this repo and navigate to the relevant working directory:

`cd Kamodo/kamodo_ccmc/readers/kamodo-JB2008
`

Then build and run the container:

```
docker compose build jb2008
docker compose up jb2008
```

To instantiate the object:

```
from jb.jb09 import KJB08
kj = KJB08()
kj
```

More directions for manipulating the object are found in the relevant README.md.
