### PR TITLE
pyverbplt has been fixed. verb reader code updated

### DIFF
--- a/kamodo_ccmc/readers/verb3d_4D.py
+++ b/kamodo_ccmc/readers/verb3d_4D.py
@@ -365,7 +365,7 @@ def MODEL():
             # functionalize the 3D or 4D dataset, series of time slices
             self = RU.Functionalize_Dataset(
                 self, coord_dict, varname, self.variables[varname],
-                gridded_int=False, coord_str=coord_str, interp_flag=0, func=func_near(),
+                gridded_int=False, coord_str=coord_str, interp_flag=0, func=func_near,
                 times_dict=None, func_default='custom')
             return
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,4 +47,4 @@ install_requires =
   h5netcdf
   psutil
   rbamlib
-  pyverbplt
+  pyverbplt>=24.9


### PR DESCRIPTION
Updating requirement of pyverbplt version 24.9 or newer. pyverbplt now should install without import issue.

@lrastaet
VERB also uses this part of the code and I had to fix it to work with this new change.
https://github.com/nasa/Kamodo/blob/893fcf5fd116827570272641ad49fa9437e0ce75/kamodo_ccmc/readers/reader_utilities.py#L189-L195


@darrendezeeuw 
All tests are passed on the isolated enviroment.