### PR TITLE
Fully support OpenGGCM_IE and compilation from Fortran sources

### DIFF
--- a/kamodo_ccmc/flythrough/model_wrapper.py
+++ b/kamodo_ccmc/flythrough/model_wrapper.py
@@ -25,6 +25,9 @@ model_dict = {'ADELPHI': 'AMPERE-Derived ELectrodynamic Properties of the ' +
               'OpenGGCM_GM': 'The Open Geospace General Circulation Model - ' +
                              'Global Magnetosphere outputs only ' +
                              'https://doi.org/10.1023/A:1014228230714',
+              'OpenGGCM_IE': 'The Open Geospace General Circulation Model - ' +
+                             'Ionosphere Electrodynamics outputs ' +
+                             'https://doi.org/10.1023/A:1014228230714',
               'SuperDARN_uni': 'SuperDARN uniform grid output ' +
                                'https://doi.org/10.1029/2010JA016017',
               'SuperDARN_equ': 'SuperDARN equal area grid output ' +
@@ -99,6 +102,10 @@ def Choose_Model(model=''):
 
     elif model == 'OpenGGCM_GM':
         import kamodo_ccmc.readers.openggcm_gm_4Dcdf as module
+        return module
+
+    elif model == 'OpenGGCM_IE':
+        import kamodo_ccmc.readers.openggcm_ie_4D as module
         return module
 
     elif model == 'AMGeO':

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ cffi
 numpy<2.0.0
 pandas<2.0.0
 netCDF4<1.7.0
-setuptools<65
 nbformat
 cdflib
 astropy
@@ -27,3 +26,4 @@ h5netcdf
 psutil
 rbamlib
 pyverbplt
+setuptools<65.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,11 @@ mknotebooks
 python-markdown-math
 markdown_include
 kamodo
+cffi
 numpy<2.0.0
 pandas<2.0.0
 netCDF4<1.7.0
+setuptools<65
 nbformat
 cdflib
 astropy

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ python_requires = >= 3.10
 include_package_data = True
 install_requires =
   kamodo
+  setuptools<65
   numpy<2.0.0
   pandas<2.0.0
   netCDF4<1.7.0


### PR DESCRIPTION
Fully support OpenGGCM_IR reader in satellite fly-through.
Added setuptools<65 to dependencies listed in requirements.txt and setup.cfg to allow compiling shared libraries from Fortran sources.