### PR TITLE
fix: replace numpy 2.0 removed APIs (np.NaN, np.float)

### DIFF
--- a/=2.0.0
+++ b/=2.0.0
@@ -1,0 +1,9 @@
+Collecting numpy
+  Downloading numpy-2.4.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (6.6 kB)
+Downloading numpy-2.4.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (16.6 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 16.6/16.6 MB 46.0 MB/s  0:00:00
+Installing collected packages: numpy
+Successfully installed numpy-2.4.3
+
+[notice] A new release of pip is available: 25.3 -> 26.0.1
+[notice] To update, run: python3 -m pip install --upgrade pip

--- a/=2.0.0
+++ b/=2.0.0
@@ -1,9 +1,0 @@
-Collecting numpy
-  Downloading numpy-2.4.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (6.6 kB)
-Downloading numpy-2.4.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (16.6 MB)
-   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 16.6/16.6 MB 46.0 MB/s  0:00:00
-Installing collected packages: numpy
-Successfully installed numpy-2.4.3
-
-[notice] A new release of pip is available: 25.3 -> 26.0.1
-[notice] To update, run: python3 -m pip install --upgrade pip

--- a/kamodo_ccmc/flythrough/SF_output.py
+++ b/kamodo_ccmc/flythrough/SF_output.py
@@ -43,7 +43,7 @@ def Functionalize_TimeSeries(utc_time, variable_name, variable_units,
 
     # Define an interpolator for the given time series array.
     interp = interp1d(utc_time, variable_data, bounds_error=False,
-                      fill_value=np.NaN)
+                      fill_value=np.nan)
 
     # Functionalize the time series array
     @kamodofy(units=variable_units, data=variable_data)  # units

--- a/kamodo_ccmc/readers/adelphi_tocdf.py
+++ b/kamodo_ccmc/readers/adelphi_tocdf.py
@@ -130,7 +130,7 @@ def combine_hemispheres(north_file, south_file):
         data[key][:, 1:, :len_lat] = np.flip(data_S[key], axis=2)  # S data
         data[key][:, 1:, len_lat] = data[key][:, 1:, len_lat-1]  # value buffer
         data[key][:, 1:, len_lat+1:len_lat+3] = \
-            np.tile(np.NaN, (new_shape[0], new_shape[1]-1, 2))  # NaN buffer
+            np.tile(np.nan, (new_shape[0], new_shape[1]-1, 2))  # NaN buffer
         data[key][:, 1:, len_lat+3] = data[key][:, 1:, len_lat+4]  # value buff
         data[key][:, 1:, len_lat+4:] = data_N[key]  # N hemisphere data
 
@@ -156,7 +156,7 @@ def combine_hemispheres(north_file, south_file):
             NP_idx -= 1
             zero_check = np.count_nonzero(data[key][:, :, NP_idx])
         # replace 'extra' latitude rows from data with NaNs
-        data[key][:, :, slice_idx] = np.tile(np.NaN, (
+        data[key][:, :, slice_idx] = np.tile(np.nan, (
             new_shape[0], new_shape[1], len(slice_idx)))
 
     # data wrangling complete, return data dictionary

--- a/kamodo_ccmc/readers/hapi.py
+++ b/kamodo_ccmc/readers/hapi.py
@@ -122,7 +122,7 @@ class HAPI(Kamodo):
                     # Fix wonky geotail data
                     aunit="nT"
                     afill = 0.1*float(afill)
-                    adata = 0.1*adata.astype(np.float)
+                    adata = 0.1*adata.astype(np.float64)
                 if aunit == "n/cc":
                     # The unit n/cc should be 1/cc to register properly in Kamodo
                     aunit = "1/cc"

--- a/kamodo_ccmc/readers/superdarn_tocdf.py
+++ b/kamodo_ccmc/readers/superdarn_tocdf.py
@@ -175,12 +175,12 @@ def df_data(df_file, verbose=False):
             tmp[:, 2:-1] = variables[var]  # copy data into grid
             tmp[:, -1] = np.mean(tmp[:, -2], axis=0)
             tmp[:, 1] = variables[var][:, 0]  # buffer row
-            tmp[:, 0] = np.NaN  # add NaNs on equator side
+            tmp[:, 0] = np.nan  # add NaNs on equator side
         else:  # south pole at beginning of array
             tmp[:, 1:-2] = variables[var]  # copy data into grid
             tmp[:, 0] = np.mean(tmp[:, 1], axis=0)
             tmp[:, -2] = variables[var][:, 0]  # buffer row
-            tmp[:, -1] = np.NaN  # add NaNs on equator side
+            tmp[:, -1] = np.nan  # add NaNs on equator side
         variables[var] = tmp
 
     # latitude wrapping in coordinate grid
@@ -357,7 +357,7 @@ def ea_data(ea_file, verbose=False):
 
         # addind NaN on equator-side assuming the data never reaches it.
         variables[var][new_vals[1]] = variables[var][lat_equator]  # buffer row
-        variables[var][new_vals[0]] = np.NaN * \
+        variables[var][new_vals[0]] = np.nan * \
             np.ones(shape=variables[var][lat_equator].shape)
 
     # hemisphere spcific data wrangling complete. return data.

--- a/kamodo_ccmc/readers/swmf_gm_octree.py
+++ b/kamodo_ccmc/readers/swmf_gm_octree.py
@@ -276,7 +276,7 @@ class SWMF_GM(Kamodo):
               ypos=OCTREE_BLOCK_GRID_FFI.new("float[]",list(xvec[:,1]))
               zpos=OCTREE_BLOCK_GRID_FFI.new("float[]",list(xvec[:,2]))
               npos=len(list(xvec[:,0]))
-              return_data=list(np.zeros(npos,dtype=np.float))
+              return_data=list(np.zeros(npos,dtype=np.float64))
               return_data_ffi=OCTREE_BLOCK_GRID_FFI.new("float[]",return_data)
  #             print(xpos,ypos,zpos,npos)
  #             print(var_data,return_data_ffi)

--- a/kamodo_ccmc/readers/verb3d_4D.py
+++ b/kamodo_ccmc/readers/verb3d_4D.py
@@ -647,7 +647,7 @@ def MODEL():
             # Check for NaN values
             nan_check = np.isnan(L) | np.isnan(Y) | np.isnan(Z)
             if np.all(nan_check):
-                return L, Y, Z, np.full(nobs, np.NaN), None, None
+                return L, Y, Z, np.full(nobs, np.nan), None, None
 
             # Handle NaN points in the input data
             L[nan_check] = np.nan
@@ -663,7 +663,7 @@ def MODEL():
             limax = min(limax + 1, num_L_grid - 1)
 
             if (Lmax > max_L_grid and Lmin > max_L_grid) or (Lmax < min_L_grid and Lmin < min_L_grid):
-                return L, Y, Z, np.full(nobs, np.NaN), limin, limax
+                return L, Y, Z, np.full(nobs, np.nan), limin, limax
 
             return L, Y, Z, None, limin, limax
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ python-markdown-math
 markdown_include
 kamodo
 cffi
-numpy<2.0.0
+numpy>=1.24.0
 pandas<2.0.0
 netCDF4<1.7.0
 nbformat

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ include_package_data = True
 install_requires =
   kamodo
   setuptools<65
-  numpy<2.0.0
+  numpy>=1.24.0
   pandas
   netCDF4<1.7.0
   nbformat


### PR DESCRIPTION
## Summary
- Replace `np.NaN` with `np.nan` (8 occurrences across 4 files)
- Replace `np.float` with `np.float64` (2 occurrences across 2 files)
- Update numpy version constraint: `numpy<2.0.0` → `numpy>=1.24.0` in both `setup.cfg` and `requirements.txt`

Resolves #154

## Changes
| File | Change |
|---|---|
| `kamodo_ccmc/flythrough/SF_output.py` | `np.NaN` → `np.nan` |
| `kamodo_ccmc/readers/adelphi_tocdf.py` | `np.NaN` → `np.nan` (2) |
| `kamodo_ccmc/readers/superdarn_tocdf.py` | `np.NaN` → `np.nan` (3) |
| `kamodo_ccmc/readers/verb3d_4D.py` | `np.NaN` → `np.nan` (2) |
| `kamodo_ccmc/readers/hapi.py` | `np.float` → `np.float64` |
| `kamodo_ccmc/readers/swmf_gm_octree.py` | `np.float` → `np.float64` |
| `setup.cfg` | `numpy<2.0.0` → `numpy>=1.24.0` |
| `requirements.txt` | `numpy<2.0.0` → `numpy>=1.24.0` |

## Context
`np.NaN` and `np.float` were removed in NumPy 2.0 ([migration guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html)). This PR updates all usages in `kamodo_ccmc` to their supported replacements.

Note: The base `kamodo` package (nasa/Kamodo-core) also requires numpy 2.0 fixes — a companion PR has been submitted there.